### PR TITLE
[feat/#11] jwt 인증 필터 구현

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/auth/controller/AuthController.java
@@ -36,4 +36,5 @@ public class AuthController {
     ) {
         // 실제 처리는 Security 필터에서 이루어지며, 이 메서드는 Swagger 명세용입니다.
     }
+    
 }

--- a/src/main/java/com/moplus/moplus_server/domain/member/service/MemberService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/member/service/MemberService.java
@@ -16,4 +16,9 @@ public class MemberService {
     public Member getMemberByEmail(String email) {
         return memberRepository.findByEmailOrThrow(email);
     }
+
+    @Transactional(readOnly = true)
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id).orElseThrow();
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/moplus/moplus_server/global/config/security/SecurityConfig.java
@@ -2,8 +2,11 @@ package com.moplus.moplus_server.global.config.security;
 
 import com.moplus.moplus_server.domain.member.service.MemberService;
 import com.moplus.moplus_server.global.security.filter.EmailPasswordAuthenticationFilter;
+import com.moplus.moplus_server.global.security.filter.JwtAuthenticationFilter;
 import com.moplus.moplus_server.global.security.handler.EmailPasswordSuccessHandler;
 import com.moplus.moplus_server.global.security.provider.EmailPasswordAuthenticationProvider;
+import com.moplus.moplus_server.global.security.provider.JwtTokenProvider;
+import com.moplus.moplus_server.global.security.utils.JwtUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,8 +14,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -32,7 +34,7 @@ public class SecurityConfig {
 
     private final MemberService memberService;
     private final EmailPasswordSuccessHandler emailPasswordSuccessHandler;
-    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtUtil jwtUtil;
 
     private String[] allowUrls = {"/", "/favicon.ico", "/swagger-ui/**", "/v3/**"};
 
@@ -43,6 +45,17 @@ public class SecurityConfig {
     public WebSecurityCustomizer configure() {
         // filter 안타게 무시
         return (web) -> web.ignoring().requestMatchers(allowUrls);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder
+                .authenticationProvider(emailPasswordAuthenticationProvider())
+                .authenticationProvider(jwtTokenProvider());
+        authenticationManagerBuilder.parentAuthenticationManager(null);
+        return authenticationManagerBuilder.build();
     }
 
 
@@ -62,34 +75,43 @@ public class SecurityConfig {
                         exception.authenticationEntryPoint((request, response, authException) ->
                                 response.setStatus(HttpStatus.UNAUTHORIZED.value()))); // 인증,인가가 되지 않은 요청 시 발생시
 
+        http.authenticationManager(authenticationManager(http));
+
         http
-                .addFilterAt(emailPasswordAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-//            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-//            .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class);
+                .addFilterAt(emailPasswordAuthenticationFilter(authenticationManager(http)),
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter(authenticationManager(http)),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
     @Bean
-    public EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter() throws Exception {
-        EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter = new EmailPasswordAuthenticationFilter(
-                authenticationManager(authenticationConfiguration));
-        emailPasswordAuthenticationFilter.setFilterProcessesUrl("/api/v1/auth/admin/login");
-        emailPasswordAuthenticationFilter.setAuthenticationSuccessHandler(emailPasswordSuccessHandler);
-        emailPasswordAuthenticationFilter.afterPropertiesSet();
-        return emailPasswordAuthenticationFilter;
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        ProviderManager providerManager = (ProviderManager) authenticationConfiguration.getAuthenticationManager();
-        providerManager.getProviders().add(emailPasswordAuthenticationProvider());
-        return configuration.getAuthenticationManager();
+    public EmailPasswordAuthenticationFilter emailPasswordAuthenticationFilter(
+            AuthenticationManager authenticationManager) throws Exception {
+        EmailPasswordAuthenticationFilter filter = new EmailPasswordAuthenticationFilter(authenticationManager);
+        filter.setFilterProcessesUrl("/api/v1/auth/admin/login");
+        filter.setAuthenticationSuccessHandler(emailPasswordSuccessHandler);
+        filter.afterPropertiesSet();
+        return filter;
     }
 
     @Bean
     public EmailPasswordAuthenticationProvider emailPasswordAuthenticationProvider() {
         return new EmailPasswordAuthenticationProvider(memberService);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager)
+            throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(authenticationManager);
+        filter.afterPropertiesSet();
+        return filter;
+    }
+
+    @Bean
+    public JwtTokenProvider jwtTokenProvider() {
+        return new JwtTokenProvider(jwtUtil, memberService);
     }
 
     @Bean

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -11,6 +11,17 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다"),
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 인증 정보입니다"),
 
+    //Auth
+    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "시큐리티 인증 정보를 찾을 수 없습니다."),
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 에러"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 Token입니다"),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 길이 및 형식이 다른 Token입니다"),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "서명이 잘못된 토큰입니다."),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "토큰이 없습니다"),
+    TOKEN_SUBJECT_FORMAT_ERROR(HttpStatus.UNAUTHORIZED, "Subject 값에 Long 타입이 아닌 다른 타입이 들어있습니다."),
+    AT_EXPIRED_AND_RT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AT는 만료되었고 RT는 비어있습니다."),
+    RT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "RT가 비어있습니다"),
+
     //모의고사
     PRACTICE_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모의고사를 찾을 수 없습니다"),
 

--- a/src/main/java/com/moplus/moplus_server/global/security/exception/JwtInvalidException.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/exception/JwtInvalidException.java
@@ -1,0 +1,14 @@
+package com.moplus.moplus_server.global.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtInvalidException extends AuthenticationException {
+
+    public JwtInvalidException(String msg) {
+        super(msg);
+    }
+
+    public JwtInvalidException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.moplus.moplus_server.global.security.filter;
+
+import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessToken = extractAccessTokenFromHeader(request);
+
+        if (StringUtils.hasText(accessToken)) {
+            Authentication jwtAuthenticationToken = new JwtAuthenticationToken(accessToken);
+            Authentication authentication = authenticationManager.authenticate(jwtAuthenticationToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader("Authorization"))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/security/handler/EmailPasswordSuccessHandler.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/handler/EmailPasswordSuccessHandler.java
@@ -2,7 +2,7 @@ package com.moplus.moplus_server.global.security.handler;
 
 import com.moplus.moplus_server.domain.member.domain.Member;
 import com.moplus.moplus_server.global.security.AuthConstants;
-import com.moplus.moplus_server.global.security.JwtUtil;
+import com.moplus.moplus_server.global.security.utils.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/moplus/moplus_server/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/provider/JwtTokenProvider.java
@@ -1,0 +1,69 @@
+package com.moplus.moplus_server.global.security.provider;
+
+import com.moplus.moplus_server.domain.member.domain.Member;
+import com.moplus.moplus_server.domain.member.service.MemberService;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.security.exception.JwtInvalidException;
+import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import com.moplus.moplus_server.global.security.utils.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider implements AuthenticationProvider {
+
+    private final JwtUtil jwtUtil;
+    private final MemberService memberService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        Claims claims = getClaims(authentication);
+        final Member member = getMemberById(claims.getSubject());
+
+        return new JwtAuthenticationToken(
+                member,
+                "",
+                List.of(new SimpleGrantedAuthority(member.getRole().getValue())
+                ));
+    }
+
+    private Claims getClaims(Authentication authentication) {
+        Claims claims;
+        try {
+            claims = jwtUtil.getAccessTokenClaims(authentication);
+        } catch (ExpiredJwtException expiredJwtException) {
+            throw new JwtInvalidException(ErrorCode.EXPIRED_TOKEN.getMessage());
+        } catch (SignatureException signatureException) {
+            throw new JwtInvalidException(ErrorCode.WRONG_TYPE_TOKEN.getMessage());
+        } catch (MalformedJwtException malformedJwtException) {
+            throw new JwtInvalidException(ErrorCode.UNSUPPORTED_TOKEN.getMessage());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new JwtInvalidException(ErrorCode.UNKNOWN_ERROR.getMessage());
+        }
+        return claims;
+    }
+
+    private Member getMemberById(String id) {
+        try {
+            return memberService.getMemberById(Long.parseLong(id));
+        } catch (Exception e) {
+            throw new BadCredentialsException(ErrorCode.BAD_CREDENTIALS.getMessage());
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/security/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/token/JwtAuthenticationToken.java
@@ -1,0 +1,38 @@
+package com.moplus.moplus_server.global.security.token;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private String jsonWebToken;
+    private Object principal;
+    private Object credentials;
+
+    public JwtAuthenticationToken(String jsonWebToken) {
+        super(null);
+        this.jsonWebToken = jsonWebToken;
+        this.setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+                                  Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true);
+    }
+
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    public String getJsonWebToken() {
+        return this.jsonWebToken;
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/security/utils/JwtUtil.java
+++ b/src/main/java/com/moplus/moplus_server/global/security/utils/JwtUtil.java
@@ -1,13 +1,16 @@
-package com.moplus.moplus_server.global.security;
+package com.moplus.moplus_server.global.security.utils;
 
 import com.moplus.moplus_server.domain.member.domain.Member;
 import com.moplus.moplus_server.global.properties.jwt.JwtProperties;
+import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -43,6 +46,16 @@ public class JwtUtil {
                 .setExpiration(expiredAt)
                 .signWith(getRefreshTokenKey())
                 .compact();
+    }
+
+    public Claims getAccessTokenClaims(Authentication authentication) {
+
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(getAccessTokenKey())
+                .build()
+                .parseClaimsJws(((JwtAuthenticationToken) authentication).getJsonWebToken())
+                .getBody();
     }
 
     private Key getAccessTokenKey() {

--- a/src/test/java/com/moplus/moplus_server/global/security/utils/JwtUtilTest.java
+++ b/src/test/java/com/moplus/moplus_server/global/security/utils/JwtUtilTest.java
@@ -1,0 +1,113 @@
+package com.moplus.moplus_server.global.security.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.moplus.moplus_server.global.properties.jwt.JwtProperties;
+import com.moplus.moplus_server.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtUtilTest {
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    @InjectMocks
+    private JwtUtil jwtUtil;
+
+    private String validToken;
+    private Key key;
+
+    @BeforeEach
+    public void setup() {
+        // Mock JwtProperties
+        when(jwtProperties.issuer()).thenReturn("testIssuer");
+        when(jwtProperties.accessTokenSecret()).thenReturn(
+                "mySecretKeymySecretKeymySecretKeymySecretKey"); // 256-bit key
+        when(jwtProperties.accessTokenExpirationMilliTime()).thenReturn(7200000L); // 1 hour
+
+        // Generate a test token
+        key = Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+        Date issuedAt = new Date();  // 3 hour ago
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        validToken = Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject("1")
+                .claim("role", "ROLE_USER")
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(key)
+                .compact();
+    }
+
+    @Test
+    public void 유효한_토큰_통과() {
+
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(validToken);
+
+        // Act
+        Claims claimsJws = jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+
+        // Assert
+        assertNotNull(claimsJws);
+        assertEquals("testIssuer", claimsJws.getIssuer());
+        assertEquals("1", claimsJws.getSubject());
+        assertEquals("ROLE_USER", claimsJws.get("role", String.class));
+    }
+
+    @Test
+    public void 만료된_토큰_예외() {
+        Date issuedAt = new Date(System.currentTimeMillis() - 10800000L);  // 3 hour ago
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String expiredToken = Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject("12345")
+                .claim("role", "ROLE_USER")
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt) // 1 hour ago
+                .signWith(key)
+                .compact();
+
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(expiredToken);
+
+        assertThrows(ExpiredJwtException.class,
+                () -> jwtUtil.getAccessTokenClaims(jwtAuthenticationToken));
+    }
+
+    @Test
+    public void 조작된_토큰_예외() {
+        //토큰 변형
+        String invalidSignatureToken = validToken.substring(0, validToken.length() - 1) + "@";
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(invalidSignatureToken);
+        assertThrows(SignatureException.class, () -> {
+            jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+        });
+    }
+
+    @Test
+    public void jwt_토큰_형식이_아닌_토큰_예외() {
+        //형식이 jwt 토큰 형식 조차 아닌 토큰
+        String malformedToken = "malformed.token.here";
+        Authentication jwtAuthenticationToken = new JwtAuthenticationToken(malformedToken);
+        assertThrows(MalformedJwtException.class, () -> {
+            jwtUtil.getAccessTokenClaims(jwtAuthenticationToken);
+        });
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #11 

## 📌 작업 내용 및 특이사항
- 저번에 구현한 이메일 패스워드 인증 후 인증 상태 유지를 위해 JwtAuthenticationFilter를 spring security에 추가하였습니다.
- <img width="1564" alt="image" src="https://github.com/user-attachments/assets/fb4a1fc8-e174-469d-9eac-eb80f3aa155a" />
- 빨간 색으로 표시한 부분이 추가 필터 로직입니다.

- 저번에 구성하였던 AuthenticationManger에 AuthenticationProvider를 구현한 JwtTokenProvider를 추가하여 여러개의 인증 Provider 관리 책임은 Manger가 하도록 유지했습니다.
- Jwt를 인증하는 책임은 JwtTokenProvider가 맡습니다.
- Filter의 순서는 JwtAuthenticationFilter -> EmailPasswordAuthenticationFilter 순 입니다. 토큰이 없을 시 다음 이메일 패스워드 필터로 넘어가는 순서입니다. 아무 인증도 없을 시 예외가 발생하고 authenticationEntryPoint가 공통적으로 처리합니다.

## 📝 테스트사항
<img width="293" alt="image" src="https://github.com/user-attachments/assets/5923ed7f-c8b4-4114-bf8b-07795deedf48" />

- jwt유효성 검사가 잘 이우러지는지 테스트를 추가했습니다.
- 기존 로그인 방식의 인증 통합 테스트도 잘 이루어지는 것을 볼 수 있습니다.

## 🎯 트러블 슈팅 
- JwtAuthenticationFilter를 추가하며 기존 로그인 통합테스트가 실패했었습니다.
    - 원인1 : spring security 6.x.x 버전으로 올라오면서 AuthenticationManger 등록방식이 수정되어서 반영하였습니다.
    - 원인2 : 기존 로그인 인증은 jwt토큰이 없는데 여기서 인증이 실패하게 되고 다음 필터로 넘어가야하는데 넘어가지 못하고 다시 jwt인증을 무한 방복하는 이슈가 있었습니다. 
 
    - <img width="693" alt="image" src="https://github.com/user-attachments/assets/2f2a40b5-61d4-43cf-9e2a-566929605010" />

    - ProviderManager는 인증이 실패하면 부모 manger의 authenticate()를 호출하게 되는데 여기서 자기 자신이 부모로 초기화되어 있었습니다.
 AuthenticationManger 등록 방식이 바뀌면서 명시적으로 AuthenticationManger의 parent를 null처리하지 않으면 자기 자신이 부모로 잡히게 됩니다. 명시적으로 null처리 하여 해결하였습니다.


## 📚 기타
해당 branch 위에서 작업 된 PR #16 이 존재합니다
- https://github.com/team-MoPlus/moplus_server/pull/16