### PR TITLE
[docs/#15] 사용하지 않는 api swagger에서 정리

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/DetailResultApplication/controller/DetailResultApplicationController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/DetailResultApplication/controller/DetailResultApplicationController.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.domain.DetailResultApplication.controller;
 import com.moplus.moplus_server.domain.DetailResultApplication.dto.request.DetailResultApplicationPostRequest;
 import com.moplus.moplus_server.domain.DetailResultApplication.dto.response.ReviewNoteGetResponse;
 import com.moplus.moplus_server.domain.DetailResultApplication.service.DetailResultApplicationService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/detailResultApplication")
@@ -20,7 +22,8 @@ public class DetailResultApplicationController {
 
     @PostMapping("")
     @Operation(summary = "모의고사 결과 상세 분석서 신청하기")
-    public ResponseEntity<ReviewNoteGetResponse> createApplication(@RequestBody DetailResultApplicationPostRequest request) {
+    public ResponseEntity<ReviewNoteGetResponse> createApplication(
+            @RequestBody DetailResultApplicationPostRequest request) {
         detailResultApplicationService.saveApplication(request);
         ReviewNoteGetResponse reviewNoteInfo = detailResultApplicationService.getReviewNoteInfo(request.testResultId());
         return ResponseEntity.ok(reviewNoteInfo);

--- a/src/main/java/com/moplus/moplus_server/domain/TestResult/controller/RatingController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/TestResult/controller/RatingController.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.domain.TestResult.controller;
 
 import com.moplus.moplus_server.domain.TestResult.dto.response.RatingGetResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequestMapping("/api/v1/rating")
 @RequiredArgsConstructor

--- a/src/main/java/com/moplus/moplus_server/domain/TestResult/controller/TestResultController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/TestResult/controller/TestResultController.java
@@ -4,6 +4,7 @@ import com.moplus.moplus_server.domain.TestResult.dto.request.IncorrectProblemPo
 import com.moplus.moplus_server.domain.TestResult.dto.request.SolvingTimePostRequest;
 import com.moplus.moplus_server.domain.TestResult.dto.response.TestResultGetResponse;
 import com.moplus.moplus_server.domain.TestResult.service.TestResultService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/testResult")
@@ -25,7 +27,7 @@ public class TestResultController {
     @PostMapping("/{practiceTestId}/uploadingAnswer")
     @Operation(summary = "답 입력 결과 제출", description = "테스트 결과지의 ID를 반환합니다.")
     public ResponseEntity<Long> uploadTestAnswers(@PathVariable("practiceTestId") Long id,
-        @RequestBody List<IncorrectProblemPostRequest> requests) {
+                                                  @RequestBody List<IncorrectProblemPostRequest> requests) {
         return ResponseEntity.ok(testResultService.createTestResult(id, requests));
     }
 
@@ -37,11 +39,11 @@ public class TestResultController {
 
     @PostMapping("/{testResultId}/uploadingMinute")
     @Operation(summary = "풀이 시간 제출 및 시험 결과지 받기",
-        description = "성적과 풀이시간에 기반한 내 위치 결과지를 반환합니다. 풀이시간은 'PT{시간}H{분}M' 형식으로 보내주세요")
+            description = "성적과 풀이시간에 기반한 내 위치 결과지를 반환합니다. 풀이시간은 'PT{시간}H{분}M' 형식으로 보내주세요")
     public ResponseEntity<TestResultGetResponse> uploadSolvingMinute(
-        @PathVariable("testResultId") Long id,
-        @RequestBody SolvingTimePostRequest request
-        ) {
+            @PathVariable("testResultId") Long id,
+            @RequestBody SolvingTimePostRequest request
+    ) {
         return ResponseEntity.ok(testResultService.getTestResultBySolvingTime(id, request));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/PracticeTestAdminController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/PracticeTestAdminController.java
@@ -1,20 +1,17 @@
 package com.moplus.moplus_server.domain.practiceTest.api.admin;
 
 import com.moplus.moplus_server.domain.practiceTest.dto.client.response.PracticeTestGetResponse;
-import com.moplus.moplus_server.domain.practiceTest.domain.PracticeTest;
 import com.moplus.moplus_server.domain.practiceTest.service.client.PracticeTestService;
 import com.moplus.moplus_server.domain.practiceTest.service.client.ProblemService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
+@Hidden
 @Controller
 @RequiredArgsConstructor
 public class PracticeTestAdminController {
@@ -30,7 +27,6 @@ public class PracticeTestAdminController {
         model.addAttribute("practiceTests", practiceTests);
         return "practiceTestList";
     }
-
 
 
 }

--- a/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/PracticeTestCreateController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/PracticeTestCreateController.java
@@ -4,6 +4,7 @@ import com.moplus.moplus_server.domain.practiceTest.dto.admin.request.PracticeTe
 import com.moplus.moplus_server.domain.practiceTest.service.admin.PracticeTestAdminService;
 import com.moplus.moplus_server.domain.practiceTest.service.client.PracticeTestService;
 import com.moplus.moplus_server.domain.practiceTest.service.client.ProblemService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+@Hidden
 @Controller
 @RequestMapping("/admin/practiceTests")
 @RequiredArgsConstructor
@@ -48,7 +50,8 @@ public class PracticeTestCreateController {
 
     @PostMapping("/submit/{id}")
     @Operation(summary = "모의고사 정보 수정 요청")
-    public String submitUpdateTestInfo(@PathVariable("id") Long id, @ModelAttribute PracticeTestRequest practiceTestRequest, Model model) {
+    public String submitUpdateTestInfo(@PathVariable("id") Long id,
+                                       @ModelAttribute PracticeTestRequest practiceTestRequest, Model model) {
 
         practiceTestAdminService.updatePracticeTest(id, practiceTestRequest);
         practiceTestAdminService.getProblemUpdateModel(model, id);

--- a/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/ProblemAdminController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/ProblemAdminController.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.domain.practiceTest.api.admin;
 import com.moplus.moplus_server.domain.practiceTest.domain.PracticeTest;
 import com.moplus.moplus_server.domain.practiceTest.service.client.PracticeTestService;
 import com.moplus.moplus_server.domain.practiceTest.service.client.ProblemService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Hidden
 @Controller
 @RequestMapping("/admin/practiceTests")
 @RequiredArgsConstructor

--- a/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/ProblemImageUploadController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/admin/ProblemImageUploadController.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.domain.practiceTest.api.admin;
 
 import com.moplus.moplus_server.domain.practiceTest.service.admin.ProblemImageUploadService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -10,9 +11,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Hidden
 @Controller
 @RequestMapping("/admin/practiceTests")
 @RequiredArgsConstructor
@@ -31,9 +32,10 @@ public class ProblemImageUploadController {
 
     @PostMapping("/uploadImage/{problemId}")
     @Operation(summary = "문제 이미지 업로드 요청")
-    public String uploadImage(@RequestParam("practiceTestId") Long practiceTestId, @PathVariable("problemId") Long problemId, @RequestParam("image") MultipartFile image) {
+    public String uploadImage(@RequestParam("practiceTestId") Long practiceTestId,
+                              @PathVariable("problemId") Long problemId, @RequestParam("image") MultipartFile image) {
         // 이미지 업로드 처리
-        problemImageUploadService.uploadImage(practiceTestId ,problemId, image);
+        problemImageUploadService.uploadImage(practiceTestId, problemId, image);
 
         return "redirect:/admin/practiceTests/imageUploadPage/" + practiceTestId;
     }

--- a/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/client/PracticeTestController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/practiceTest/api/client/PracticeTestController.java
@@ -1,8 +1,8 @@
 package com.moplus.moplus_server.domain.practiceTest.api.client;
 
 import com.moplus.moplus_server.domain.practiceTest.dto.client.response.PracticeTestGetResponse;
-import com.moplus.moplus_server.domain.practiceTest.service.client.OptimisticLockPracticeTestFacade;
 import com.moplus.moplus_server.domain.practiceTest.service.client.PracticeTestService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/practiceTests")


### PR DESCRIPTION
## 🌱 관련 이슈
- close #15 

## 📌 작업 내용 및 특이사항
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/84408cf9-bc46-449d-b3ea-ab4b56becaf8" />

- 사용하지 않는 이전 API를 swagger에서 뜨지 않게 수정하였습니다.
- 쓰지 않는 Controller에 @Hidden 을 달아주었습니다.

## 주의
- 해당 pr #11 브랜치 위에서 작업되었습니다. #11 을 먼저 리뷰해주세요

