### PR TITLE
Feature/#21 문항, 새끼문항, 개념태그 엔티티 구현

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/concept/domain/ConceptTag.java
+++ b/src/main/java/com/moplus/moplus_server/domain/concept/domain/ConceptTag.java
@@ -20,4 +20,8 @@ public class ConceptTag extends BaseEntity {
     Long id;
 
     String name;
+
+    public ConceptTag(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/concept/domain/ConceptTag.java
+++ b/src/main/java/com/moplus/moplus_server/domain/concept/domain/ConceptTag.java
@@ -1,0 +1,23 @@
+package com.moplus.moplus_server.domain.concept.domain;
+
+import com.moplus.moplus_server.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ConceptTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "concept_tag_id")
+    Long id;
+
+    String name;
+}

--- a/src/main/java/com/moplus/moplus_server/domain/concept/repository/ConceptTagRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/concept/repository/ConceptTagRepository.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.domain.concept.repository;
+
+import com.moplus.moplus_server.domain.concept.domain.ConceptTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConceptTagRepository extends JpaRepository<ConceptTag, Long> {
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/ChildProblem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/ChildProblem.java
@@ -1,0 +1,35 @@
+package com.moplus.moplus_server.domain.problem.domain;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ChildProblem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_id")
+    Long id;
+    @ElementCollection
+    @CollectionTable(name = "child_problem_concept", joinColumns = @JoinColumn(name = "concept_tag_id"))
+    Set<Long> conceptTagIds;
+    private String problemImageUrl;
+    private String answer;
+
+    public ChildProblem(String problemImageUrl, String answer, Set<Long> conceptTagIds) {
+        this.problemImageUrl = problemImageUrl;
+        this.answer = answer;
+        this.conceptTagIds = conceptTagIds;
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
@@ -1,0 +1,47 @@
+package com.moplus.moplus_server.domain.problem.domain;
+
+import com.moplus.moplus_server.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Problem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_id")
+    Long id;
+
+    String practiceTestId;
+    int number;
+    int answer;
+    String comment;
+    String mainProblemImageUrl;
+    String mainAnalysisImageUrl;
+    String readingTipImageUrl;
+    String seniorTipImageUrl;
+    String prescriptionImageUrl;
+
+    @ElementCollection
+    @CollectionTable(name = "problem_concept", joinColumns = @JoinColumn(name = "concept_tag_id"))
+    Set<Long> conceptTagIds;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "problem_id")
+    private List<ChildProblem> childProblems = new ArrayList<>();
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
@@ -6,6 +6,7 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -41,7 +42,7 @@ public class Problem extends BaseEntity {
     @CollectionTable(name = "problem_concept", joinColumns = @JoinColumn(name = "concept_tag_id"))
     Set<Long> conceptTagIds;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     private List<ChildProblem> childProblems = new ArrayList<>();
 

--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/Problem.java
@@ -44,4 +44,19 @@ public class Problem extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "problem_id")
     private List<ChildProblem> childProblems = new ArrayList<>();
+
+    public Problem(String practiceTestId, int number, int answer, String comment, String mainProblemImageUrl,
+                   String mainAnalysisImageUrl, String readingTipImageUrl, String seniorTipImageUrl,
+                   String prescriptionImageUrl, Set<Long> conceptTagIds) {
+        this.practiceTestId = practiceTestId;
+        this.number = number;
+        this.answer = answer;
+        this.comment = comment;
+        this.mainProblemImageUrl = mainProblemImageUrl;
+        this.mainAnalysisImageUrl = mainAnalysisImageUrl;
+        this.readingTipImageUrl = readingTipImageUrl;
+        this.seniorTipImageUrl = seniorTipImageUrl;
+        this.prescriptionImageUrl = prescriptionImageUrl;
+        this.conceptTagIds = conceptTagIds;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problem/repository/ChildProblemRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/repository/ChildProblemRepository.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.domain.problem.repository;
+
+import com.moplus.moplus_server.domain.problem.domain.ChildProblem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildProblemRepository extends JpaRepository<ChildProblem, Long> {
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.domain.problem.repository;
+
+import com.moplus.moplus_server.domain.problem.domain.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #21 

---

## 📌 작업 내용 및 특이사항
<img width="500" alt="image" src="https://github.com/user-attachments/assets/fee566e4-baf9-4b63-a701-119ab11eb1ab" />

### **1. 문항, 새끼 문항, 개념 태그 구성**
- **문항**, **새끼 문항**, **개념 태그**를 각각 독립적인 **애그리거트**로 구성하였습니다.
- 초기에는 문항과 새끼 문항을 하나의 애그리거트로 간주했으나, 출제진의 문제 업로드 과정을 분석한 결과, 두 엔티티의 생명주기가 다르다는 점을 확인했습니다.
- **문항의 처리 흐름**:
  1. 문항 등록
  2. 세트로 묶기
  3. 문항에 새끼 문항 추가
  4. 수정 및 삭제 가능
- 이러한 흐름에 따라 **문항**과 **새끼 문항**은 별도의 애그리거트로 설계되었습니다.

---

### **2. 문항과 개념 태그: 단방향 연관관계로 설계**

#### **2.1 개념 태그 → 문항 관계**
- **개념 태그가 문항을 알 필요가 있는가?**
   ```java
    public class ConceptTag {

        private Set<Problem> problems = new HashSet<>();

    }
   ```
  - 특정 개념 태그로 문항을 필터링하는 상황에서는 유용할 수 있지만, 개념 태그에 연결된 문항이 많아질 경우 **(예를 들어 수 만건 정도) 모든 문항을 한 번에 로드해야 하는 성능 문제**가 발생합니다.
  - 페이지네이션으로 문항의 로드를 제한한다고 해도, `problems` 필드를 읽는 순간 결국엔 똑같이 많은 데이터를 로드하고 어플리케이션 내에서 필터링하게 됩니다.
  - **결론**: 개념 태그는 문항의 정보를 직접 참조하지 않도록 설계.

#### **2.2 문항 → 개념 태그 관계**
- 문항은 자신에게 달린 개념 태그를 반드시 알아야 하므로, **문항에서 개념 태그를 조회**하는 단방향 연관관계를 설계했습니다.
- **객체 참조 vs ID 참조**:
  - **객체 참조**:
    ```java
    public class Problem {
        @ElementCollection
        @CollectionTable(name = "problem_concept", joinColumns = @JoinColumn(name = "concept_tag_id"))
        Set<ConceptTag> conceptTags;
    }
    ```
    - 다른 애그리거트에 대한 직접 참조는 불필요한 수정 범위 증가를 초래할 수 있어 지양.
  - **ID 참조**:
    ```java
    public class Problem {
        @ElementCollection
        @CollectionTable(name = "problem_concept", joinColumns = @JoinColumn(name = "concept_tag_id"))
        Set<Long> conceptTagIds;
    }
    ```
    - ID 참조 방식을 선택하여 **수정 가능 범위를 최소화**.
    - 필요 시 **join 쿼리**를 사용하여 개념 태그와 문항 데이터를 결합.
    - 객체 참조 방식에서도 **Lazy Loading**으로 인해 N+1 문제가 발생할 수 있으므로 성능 면에서 큰 차이는 없습니다.

---

### **3. 문항과 새끼 문항: 단방향 연관관계 설계**

#### **3.1 연관관계 주인의 설정**
- 일반적으로 일대다 관계에서는 **외래 키가 있는 "다" 쪽**(즉, 자식 엔티티)이 연관관계 주인이 됩니다.
- 하지만 **새끼 문항은 문항 페이지 내에서 생성 및 관리**되며, 자신이 어떤 문항에 속하는지 직접 알 필요가 없다고 판단했습니다.
- 이에 따라 '일'쪽이 연관관계 주인이 되는 **문항 → 새끼 문항**의 단방향 연관관계를 구성하였습니다:
   ```java
   @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "problem_id")
   private List<ChildProblem> childProblems = new ArrayList<>();
  ```

#### **3.2 설계 결정**

- **생명주기**: 문항과 새끼 문항의 생명주기가 달라 별도의 애그리거트로 설계하였습니다.
- **조회 성능**: 문항 조회 시 새끼 문항을 반드시 같이 조회해야 하는건 아니므로, Lazy 로딩을 적용했습니다.
- **최대 개수**: 새끼 문항은 문항 당 최대 5개로 제한되므로, 새끼 문항을 항상 전부 조회해와도 성능 문제의 우려가 거의 없습니다.
- **영속성 전파 및 고아 객체 제거**:
  - `CascadeType.ALL`: 문항 저장/수정/삭제 시 새끼 문항도 함께 처리되도록 설정하였습니다.
  - `orphanRemoval = true`: 문항과의 관계가 끊어진 새끼 문항은 데이터베이스에서 자동으로 삭제됩니다.
 
### **결론**

1. **문항 ↔ 개념 태그**
   - 단방향 ID 참조 방식을 채택하였습니다.
   - N+1 문제를 방지하기 위해 필요한 경우, `join` 쿼리를 사용하여 개념 태그와 문항 데이터를 결합할 예정입니다.

2. **문항 ↔ 새끼 문항**
   - 문항에서 새끼 문항을 관리하는 단방향 연관관계로 설계하였습니다.
   - `cascade = CascadeType.ALL, orphanRemoval = true` 설정으로 문항과 새끼 문항 간의 생명주기를 일치시켰으며, 데이터 일관성을 보장하였습니다.