### PR TITLE
Feature/#29 문항 세트, 발행 도메인 및 문항세트 생성, 수정, 삭제, 컨펌 API 구현

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/problem/Problem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/problem/Problem.java
@@ -123,7 +123,11 @@ public class Problem extends BaseEntity {
 
     public boolean isValid() {
         return answer != null && !answer.getValue().isEmpty()
-                && conceptTagIds != null && !conceptTagIds.isEmpty()
+                && practiceTestId != null
+                && comment != null && !comment.isEmpty()
+                && readingTipImageUrl != null && !readingTipImageUrl.isEmpty()
+                && seniorTipImageUrl != null && !seniorTipImageUrl.isEmpty()
+                && prescriptionImageUrl != null && !prescriptionImageUrl.isEmpty()
                 && mainProblemImageUrl != null && !mainProblemImageUrl.isEmpty()
                 && mainAnalysisImageUrl != null && !mainAnalysisImageUrl.isEmpty();
     }

--- a/src/main/java/com/moplus/moplus_server/domain/problem/domain/problem/Problem.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/domain/problem/Problem.java
@@ -120,4 +120,11 @@ public class Problem extends BaseEntity {
     public void deleteChildProblem(List<Long> deleteChildProblems) {
         childProblems.removeIf(childProblem -> deleteChildProblems.contains(childProblem.getId()));
     }
+
+    public boolean isValid() {
+        return answer != null && !answer.getValue().isEmpty()
+                && conceptTagIds != null && !conceptTagIds.isEmpty()
+                && mainProblemImageUrl != null && !mainProblemImageUrl.isEmpty()
+                && mainAnalysisImageUrl != null && !mainAnalysisImageUrl.isEmpty();
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
@@ -1,11 +1,14 @@
 package com.moplus.moplus_server.domain.problemset.controller;
 
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
 import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,10 +21,19 @@ public class ProblemSetController {
     private final ProblemSetSaveService problemSetSaveService;
 
     @PostMapping("")
-    @Operation(summary = "문항세트 생성", description = "세트를 생성합니다. 문항은 요청 순서대로 저장합니다.")
+    @Operation(summary = "문항세트 생성", description = "문항세트를 생성합니다. 문항은 요청 순서대로 저장합니다.")
     public ResponseEntity<Long> createProblemSet(
             @RequestBody ProblemSetPostRequest request
     ) {
         return ResponseEntity.ok(problemSetSaveService.createProblemSet(request));
+    }
+
+    @PutMapping("/{problemSetId}/sequence")
+    @Operation(summary = "세트 문항순서 변경", description = "문항세트 내의 문항 리스트의 순서를 변경합니다.")
+    public ResponseEntity<Void> reorderProblems(
+            @PathVariable Long problemSetId,
+            @RequestBody ProblemReorderRequest problemReorderRequest) {
+        problemSetSaveService.reorderProblems(problemSetId, problemReorderRequest);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
@@ -1,5 +1,6 @@
 package com.moplus.moplus_server.domain.problemset.controller;
 
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
@@ -64,8 +65,7 @@ public class ProblemSetController {
 
     @PutMapping("/{problemSetId}/confirm")
     @Operation(summary = "문항세트 컨펌 토글", description = "문항세트의 컨펌 상태를 토글합니다.")
-    public ResponseEntity<Boolean> toggleConfirmProblemSet(@PathVariable Long problemSetId) {
-        boolean updatedState = problemSetUpdateService.toggleConfirmProblemSet(problemSetId);
-        return ResponseEntity.ok(updatedState);
+    public ResponseEntity<ProblemSetConfirmStatus> toggleConfirmProblemSet(@PathVariable Long problemSetId) {
+        return ResponseEntity.ok(problemSetUpdateService.toggleConfirmProblemSet(problemSetId));
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
@@ -1,0 +1,27 @@
+package com.moplus.moplus_server.domain.problemset.controller;
+
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/problemSet")
+@RequiredArgsConstructor
+public class ProblemSetController {
+
+    private final ProblemSetSaveService problemSetSaveService;
+
+    @PostMapping("")
+    @Operation(summary = "문항세트 생성", description = "세트를 생성합니다. 문항은 요청 순서대로 저장합니다.")
+    public ResponseEntity<Long> createProblemSet(
+            @RequestBody ProblemSetPostRequest request
+    ) {
+        return ResponseEntity.ok(problemSetSaveService.createProblemSet(request));
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
@@ -3,7 +3,9 @@ package com.moplus.moplus_server.domain.problemset.controller;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetDeleteService;
 import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetUpdateService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemSetController {
 
     private final ProblemSetSaveService problemSetSaveService;
+    private final ProblemSetUpdateService problemSetUpdateService;
+    private final ProblemSetDeleteService problemSetDeleteService;
 
     @PostMapping("")
     @Operation(summary = "문항세트 생성", description = "문항세트를 생성합니다. 문항은 요청 순서대로 저장합니다.")
@@ -35,7 +39,7 @@ public class ProblemSetController {
     public ResponseEntity<Void> reorderProblems(
             @PathVariable Long problemSetId,
             @RequestBody ProblemReorderRequest request) {
-        problemSetSaveService.reorderProblems(problemSetId, request);
+        problemSetUpdateService.reorderProblems(problemSetId, request);
         return ResponseEntity.noContent().build();
     }
 
@@ -45,7 +49,7 @@ public class ProblemSetController {
             @PathVariable Long problemSetId,
             @RequestBody ProblemSetUpdateRequest request
     ) {
-        problemSetSaveService.updateProblemSet(problemSetId, request);
+        problemSetUpdateService.updateProblemSet(problemSetId, request);
         return ResponseEntity.noContent().build();
     }
 
@@ -54,14 +58,14 @@ public class ProblemSetController {
     public ResponseEntity<Void> deleteProblemSet(
             @PathVariable Long problemSetId
     ) {
-        problemSetSaveService.deleteProblemSet(problemSetId);
+        problemSetDeleteService.deleteProblemSet(problemSetId);
         return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/{problemSetId}/confirm")
     @Operation(summary = "문항세트 컨펌 토글", description = "문항세트의 컨펌 상태를 토글합니다.")
     public ResponseEntity<Boolean> toggleConfirmProblemSet(@PathVariable Long problemSetId) {
-        boolean updatedState = problemSetSaveService.toggleConfirmProblemSet(problemSetId);
+        boolean updatedState = problemSetUpdateService.toggleConfirmProblemSet(problemSetId);
         return ResponseEntity.ok(updatedState);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetController.java
@@ -2,10 +2,12 @@ package com.moplus.moplus_server.domain.problemset.controller;
 
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
 import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,8 +34,34 @@ public class ProblemSetController {
     @Operation(summary = "세트 문항순서 변경", description = "문항세트 내의 문항 리스트의 순서를 변경합니다.")
     public ResponseEntity<Void> reorderProblems(
             @PathVariable Long problemSetId,
-            @RequestBody ProblemReorderRequest problemReorderRequest) {
-        problemSetSaveService.reorderProblems(problemSetId, problemReorderRequest);
+            @RequestBody ProblemReorderRequest request) {
+        problemSetSaveService.reorderProblems(problemSetId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{problemSetId}")
+    @Operation(summary = "문항세트 수정", description = "문항세트의 이름 및 문항 리스트를 수정합니다.")
+    public ResponseEntity<Void> updateProblemSet(
+            @PathVariable Long problemSetId,
+            @RequestBody ProblemSetUpdateRequest request
+    ) {
+        problemSetSaveService.updateProblemSet(problemSetId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{problemSetId}")
+    @Operation(summary = "문항세트 삭제", description = "문항세트를 삭제합니다. (soft delete)")
+    public ResponseEntity<Void> deleteProblemSet(
+            @PathVariable Long problemSetId
+    ) {
+        problemSetSaveService.deleteProblemSet(problemSetId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{problemSetId}/confirm")
+    @Operation(summary = "문항세트 컨펌 토글", description = "문항세트의 컨펌 상태를 토글합니다.")
+    public ResponseEntity<Boolean> toggleConfirmProblemSet(@PathVariable Long problemSetId) {
+        boolean updatedState = problemSetSaveService.toggleConfirmProblemSet(problemSetId);
+        return ResponseEntity.ok(updatedState);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -1,5 +1,6 @@
 package com.moplus.moplus_server.domain.problemset.domain;
 
+import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.global.common.BaseEntity;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -34,7 +35,7 @@ public class ProblemSet extends BaseEntity {
     @ElementCollection
     @CollectionTable(name = "problem_set_problems", joinColumns = @JoinColumn(name = "problem_set_id"))
     @Column(name = "problem_id")
-    private Set<String> problemIds = new HashSet<>();
+    private Set<ProblemId> problemIds = new HashSet<>();
 
     @Builder
     public ProblemSet(String name) {

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -5,14 +5,14 @@ import com.moplus.moplus_server.global.common.BaseEntity;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import java.util.HashSet;
-import java.util.Set;
+import jakarta.persistence.OrderColumn;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,7 +35,8 @@ public class ProblemSet extends BaseEntity {
     @ElementCollection
     @CollectionTable(name = "problem_set_problems", joinColumns = @JoinColumn(name = "problem_set_id"))
     @Column(name = "problem_id")
-    private Set<ProblemId> problemIds = new HashSet<>();
+    @OrderColumn(name = "sequence")
+    private List<ProblemId> problemIds = new ArrayList<>();
 
     @Builder
     public ProblemSet(String name) {
@@ -44,4 +45,8 @@ public class ProblemSet extends BaseEntity {
         this.isConfirmed = false;
     }
 
+    public void updateProblemOrder(List<ProblemId> newProblems) {
+        this.problemIds.clear();
+        this.problemIds.addAll(newProblems);
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -6,6 +6,8 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,7 +32,9 @@ public class ProblemSet extends BaseEntity {
 
     private String name;
     private boolean isDeleted;
-    private boolean isConfirmed;
+
+    @Enumerated(EnumType.STRING)
+    private ProblemSetConfirmStatus confirmStatus;
 
     @ElementCollection
     @CollectionTable(name = "problem_set_problems", joinColumns = @JoinColumn(name = "problem_set_id"))
@@ -42,7 +46,7 @@ public class ProblemSet extends BaseEntity {
     public ProblemSet(String name) {
         this.name = name;
         this.isDeleted = false;
-        this.isConfirmed = false;
+        this.confirmStatus = ProblemSetConfirmStatus.NOT_CONFIRMED;
     }
 
     public void updateProblemOrder(List<ProblemId> newProblems) {
@@ -54,8 +58,12 @@ public class ProblemSet extends BaseEntity {
         this.isDeleted = true;
     }
 
-    public void toggleConfirm(boolean isConfirmed) {
-        this.isConfirmed = isConfirmed;
+    public void toggleConfirm() {
+        if (this.confirmStatus == ProblemSetConfirmStatus.CONFIRMED) {
+            this.confirmStatus = ProblemSetConfirmStatus.NOT_CONFIRMED;
+        } else {
+            this.confirmStatus = ProblemSetConfirmStatus.CONFIRMED;
+        }
     }
 
     public void updateProblemSet(String name, List<ProblemId> newProblems) {

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -49,4 +49,17 @@ public class ProblemSet extends BaseEntity {
         this.problemIds.clear();
         this.problemIds.addAll(newProblems);
     }
+
+    public void deleteProblemSet() {
+        this.isDeleted = true;
+    }
+
+    public void toggleConfirm(boolean isConfirmed) {
+        this.isConfirmed = isConfirmed;
+    }
+
+    public void updateProblemSet(String name, List<ProblemId> newProblems) {
+        this.name = name;
+        this.problemIds = newProblems;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -43,15 +43,15 @@ public class ProblemSet extends BaseEntity {
     private List<ProblemId> problemIds = new ArrayList<>();
 
     @Builder
-    public ProblemSet(String name) {
+    public ProblemSet(String name, List<ProblemId> problemIds) {
         this.name = name;
         this.isDeleted = false;
         this.confirmStatus = ProblemSetConfirmStatus.NOT_CONFIRMED;
+        this.problemIds = problemIds;
     }
 
     public void updateProblemOrder(List<ProblemId> newProblems) {
-        this.problemIds.clear();
-        this.problemIds.addAll(newProblems);
+        this.problemIds = new ArrayList<>(newProblems);
     }
 
     public void deleteProblemSet() {

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -1,0 +1,46 @@
+package com.moplus.moplus_server.domain.problemset.domain;
+
+import com.moplus.moplus_server.global.common.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemSet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_set_id")
+    Long id;
+
+    private String name;
+    private boolean isDeleted;
+    private boolean isConfirmed;
+
+    @ElementCollection
+    @CollectionTable(name = "problem_set_problems", joinColumns = @JoinColumn(name = "problem_set_id"))
+    @Column(name = "problem_id")
+    private Set<String> problemIds = new HashSet<>();
+
+    @Builder
+    public ProblemSet(String name) {
+        this.name = name;
+        this.isDeleted = false;
+        this.isConfirmed = false;
+    }
+
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -1,7 +1,10 @@
 package com.moplus.moplus_server.domain.problemset.domain;
 
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.global.common.BaseEntity;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -58,12 +61,16 @@ public class ProblemSet extends BaseEntity {
         this.isDeleted = true;
     }
 
-    public void toggleConfirm() {
-        if (this.confirmStatus == ProblemSetConfirmStatus.CONFIRMED) {
-            this.confirmStatus = ProblemSetConfirmStatus.NOT_CONFIRMED;
-        } else {
-            this.confirmStatus = ProblemSetConfirmStatus.CONFIRMED;
+    public void toggleConfirm(List<Problem> problems) {
+        if(this.confirmStatus == ProblemSetConfirmStatus.NOT_CONFIRMED){
+            // 문항 유효성 검사
+            for (Problem problem : problems) {
+                if (!problem.isValid()) {
+                    throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
+                }
+            }
         }
+        this.confirmStatus = this.confirmStatus.toggle();
     }
 
     public void updateProblemSet(String name, List<ProblemId> newProblems) {

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSetConfirmStatus.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSetConfirmStatus.java
@@ -2,5 +2,8 @@ package com.moplus.moplus_server.domain.problemset.domain;
 
 public enum ProblemSetConfirmStatus {
     CONFIRMED,
-    NOT_CONFIRMED
+    NOT_CONFIRMED;
+    public ProblemSetConfirmStatus toggle() {
+        return this == CONFIRMED ? NOT_CONFIRMED : CONFIRMED;
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSetConfirmStatus.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSetConfirmStatus.java
@@ -1,0 +1,6 @@
+package com.moplus.moplus_server.domain.problemset.domain;
+
+public enum ProblemSetConfirmStatus {
+    CONFIRMED,
+    NOT_CONFIRMED
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemReorderRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemReorderRequest.java
@@ -1,0 +1,8 @@
+package com.moplus.moplus_server.domain.problemset.dto.request;
+
+import java.util.List;
+
+public record ProblemReorderRequest(
+        List<String> newProblems
+) {
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
@@ -1,0 +1,15 @@
+package com.moplus.moplus_server.domain.problemset.dto.request;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import java.util.List;
+
+public record ProblemSetPostRequest(
+        String problemSetName,
+        List<String> problems
+) {
+    public ProblemSet toEntity(String problemSetName) {
+        return ProblemSet.builder()
+                .name(problemSetName)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
@@ -1,5 +1,6 @@
 package com.moplus.moplus_server.domain.problemset.dto.request;
 
+import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import java.util.List;
 
@@ -7,9 +8,10 @@ public record ProblemSetPostRequest(
         String problemSetName,
         List<String> problems
 ) {
-    public ProblemSet toEntity() {
+    public ProblemSet toEntity(List<ProblemId> problemIdList) {
         return ProblemSet.builder()
                 .name(this.problemSetName)
+                .problemIds(problemIdList)
                 .build();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetPostRequest.java
@@ -7,9 +7,9 @@ public record ProblemSetPostRequest(
         String problemSetName,
         List<String> problems
 ) {
-    public ProblemSet toEntity(String problemSetName) {
+    public ProblemSet toEntity() {
         return ProblemSet.builder()
-                .name(problemSetName)
+                .name(this.problemSetName)
                 .build();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetUpdateRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/request/ProblemSetUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.moplus.moplus_server.domain.problemset.dto.request;
+
+import java.util.List;
+
+public record ProblemSetUpdateRequest(
+        String problemSetName,
+        List<String> problems
+) {
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
@@ -1,8 +1,14 @@
 package com.moplus.moplus_server.domain.problemset.repository;
 
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemSetRepository extends JpaRepository<ProblemSet, Long> {
+
+    default ProblemSet findByIdElseThrow(Long problemSetId) {
+        return findById(problemSetId).orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_SET_NOT_FOUND));
+    }
 
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
@@ -1,0 +1,8 @@
+package com.moplus.moplus_server.domain.problemset.repository;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemSetRepository extends JpaRepository<ProblemSet, Long> {
+
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetDeleteService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetDeleteService.java
@@ -1,0 +1,21 @@
+package com.moplus.moplus_server.domain.problemset.service;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSetDeleteService {
+
+    private final ProblemSetRepository problemSetRepository;
+
+    @Transactional
+    public void deleteProblemSet(Long problemSetId) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+        problemSet.deleteProblemSet();
+    }
+
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -3,9 +3,11 @@ package com.moplus.moplus_server.domain.problemset.service;
 import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,5 +33,17 @@ public class ProblemSetSaveService {
         ProblemSet problemSet = request.toEntity(request.problemSetName());
 
         return problemSetRepository.save(problemSet).getId();
+    }
+
+    @Transactional
+    public void reorderProblems(Long problemSetId, ProblemReorderRequest problemReorderRequest) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 기존 문항 ID 리스트 업데이트 (순서 반영)
+        List<ProblemId> updatedProblemIds = problemReorderRequest.newProblems().stream()
+                .map(ProblemId::new)
+                .collect(Collectors.toList());
+
+        problemSet.updateProblemOrder(updatedProblemIds);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -31,7 +31,7 @@ public class ProblemSetSaveService {
         problemIdList.forEach(problemRepository::findByIdElseThrow);
 
         // ProblemSet 생성
-        ProblemSet problemSet = request.toEntity();
+        ProblemSet problemSet = request.toEntity(problemIdList);
 
         return problemSetRepository.save(problemSet).getId();
     }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -31,7 +31,7 @@ public class ProblemSetSaveService {
         problemIdList.forEach(problemRepository::findByIdElseThrow);
 
         // ProblemSet 생성
-        ProblemSet problemSet = request.toEntity(request.problemSetName());
+        ProblemSet problemSet = request.toEntity();
 
         return problemSetRepository.save(problemSet).getId();
     }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -35,44 +35,4 @@ public class ProblemSetSaveService {
 
         return problemSetRepository.save(problemSet).getId();
     }
-
-    @Transactional
-    public void reorderProblems(Long problemSetId, ProblemReorderRequest request) {
-        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-
-        // 기존 문항 ID 리스트 업데이트 (순서 반영)
-        List<ProblemId> updatedProblemIds = request.newProblems().stream()
-                .map(ProblemId::new)
-                .collect(Collectors.toList());
-
-        problemSet.updateProblemOrder(updatedProblemIds);
-    }
-
-    @Transactional
-    public void updateProblemSet(Long problemSetId, ProblemSetUpdateRequest request) {
-        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-
-        // 문항 리스트 검증
-        List<ProblemId> problemIdList = request.problems().stream()
-                .map(ProblemId::new)
-                .collect(Collectors.toList());
-        problemIdList.forEach(problemRepository::findByIdElseThrow);
-
-        problemSet.updateProblemSet(request.problemSetName(), problemIdList);
-    }
-
-    @Transactional
-    public void deleteProblemSet(Long problemSetId) {
-        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-        problemSet.deleteProblemSet();
-    }
-
-    @Transactional
-    public boolean toggleConfirmProblemSet(Long problemSetId) {
-        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-
-        // 현재 상태 반전 (true → false, false → true)
-        problemSet.toggleConfirm(!problemSet.isConfirmed());
-        return problemSet.isConfirmed();
-    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -5,6 +5,7 @@ import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,14 +37,42 @@ public class ProblemSetSaveService {
     }
 
     @Transactional
-    public void reorderProblems(Long problemSetId, ProblemReorderRequest problemReorderRequest) {
+    public void reorderProblems(Long problemSetId, ProblemReorderRequest request) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
 
         // 기존 문항 ID 리스트 업데이트 (순서 반영)
-        List<ProblemId> updatedProblemIds = problemReorderRequest.newProblems().stream()
+        List<ProblemId> updatedProblemIds = request.newProblems().stream()
                 .map(ProblemId::new)
                 .collect(Collectors.toList());
 
         problemSet.updateProblemOrder(updatedProblemIds);
+    }
+
+    @Transactional
+    public void updateProblemSet(Long problemSetId, ProblemSetUpdateRequest request) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 문항 리스트 검증
+        List<ProblemId> problemIdList = request.problems().stream()
+                .map(ProblemId::new)
+                .collect(Collectors.toList());
+        problemIdList.forEach(problemRepository::findByIdElseThrow);
+
+        problemSet.updateProblemSet(request.problemSetName(), problemIdList);
+    }
+
+    @Transactional
+    public void deleteProblemSet(Long problemSetId) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+        problemSet.deleteProblemSet();
+    }
+
+    @Transactional
+    public boolean toggleConfirmProblemSet(Long problemSetId) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 현재 상태 반전 (true → false, false → true)
+        problemSet.toggleConfirm(!problemSet.isConfirmed());
+        return problemSet.isConfirmed();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetSaveService.java
@@ -1,0 +1,35 @@
+package com.moplus.moplus_server.domain.problemset.service;
+
+import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
+import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSetSaveService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemRepository problemRepository;
+
+    @Transactional
+    public Long createProblemSet(ProblemSetPostRequest request) {
+        // 문제 ID 리스트를 ProblemId 객체로 변환
+        List<ProblemId> problemIdList = request.problems().stream()
+                .map(ProblemId::new)
+                .toList();
+
+        // 모든 문항이 DB에 존재하는지 검증
+        problemIdList.forEach(problemRepository::findByIdElseThrow);
+
+        // ProblemSet 생성
+        ProblemSet problemSet = request.toEntity(request.problemSetName());
+
+        return problemSetRepository.save(problemSet).getId();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -10,6 +10,7 @@ import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRe
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -51,19 +52,12 @@ public class ProblemSetUpdateService {
     @Transactional
     public ProblemSetConfirmStatus toggleConfirmProblemSet(Long problemSetId) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-
-        if(problemSet.getConfirmStatus() == ProblemSetConfirmStatus.NOT_CONFIRMED){
-            // 문항 유효성 검사
-            for (ProblemId problemId : problemSet.getProblemIds()) {
-                Problem problem = problemRepository.findByIdElseThrow(problemId);
-
-                if (!problem.isValid()) {
-                    throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
-                }
-            }
+        List<Problem> problems = new ArrayList<>();
+        for (ProblemId problemId : problemSet.getProblemIds()) {
+            Problem problem = problemRepository.findByIdElseThrow(problemId);
+            problems.add(problem);
         }
-
-        problemSet.toggleConfirm();
+        problemSet.toggleConfirm(problems);
         return problemSet.getConfirmStatus();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -1,0 +1,55 @@
+package com.moplus.moplus_server.domain.problemset.service;
+
+import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
+import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSetUpdateService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemRepository problemRepository;
+
+    @Transactional
+    public void reorderProblems(Long problemSetId, ProblemReorderRequest request) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 기존 문항 ID 리스트 업데이트 (순서 반영)
+        List<ProblemId> updatedProblemIds = request.newProblems().stream()
+                .map(ProblemId::new)
+                .collect(Collectors.toList());
+
+        problemSet.updateProblemOrder(updatedProblemIds);
+    }
+
+    @Transactional
+    public void updateProblemSet(Long problemSetId, ProblemSetUpdateRequest request) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 문항 리스트 검증
+        List<ProblemId> problemIdList = request.problems().stream()
+                .map(ProblemId::new)
+                .collect(Collectors.toList());
+        problemIdList.forEach(problemRepository::findByIdElseThrow);
+
+        problemSet.updateProblemSet(request.problemSetName(), problemIdList);
+    }
+
+    @Transactional
+    public boolean toggleConfirmProblemSet(Long problemSetId) {
+        ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+
+        // 현재 상태 반전 (true → false, false → true)
+        problemSet.toggleConfirm(!problemSet.isConfirmed());
+        return problemSet.isConfirmed();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -4,6 +4,7 @@ import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
@@ -48,7 +49,7 @@ public class ProblemSetUpdateService {
     }
 
     @Transactional
-    public boolean toggleConfirmProblemSet(Long problemSetId) {
+    public ProblemSetConfirmStatus toggleConfirmProblemSet(Long problemSetId) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
 
         // 문항 유효성 검사
@@ -60,9 +61,7 @@ public class ProblemSetUpdateService {
             }
         }
 
-        // 현재 상태 반전 (true → false, false → true)
-        problemSet.toggleConfirm(!problemSet.isConfirmed());
-        return problemSet.isConfirmed();
+        problemSet.toggleConfirm();
+        return problemSet.getConfirmStatus();
     }
-
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -1,11 +1,14 @@
 package com.moplus.moplus_server.domain.problemset.service;
 
+import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import com.moplus.moplus_server.domain.problem.domain.problem.ProblemId;
 import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
 import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -48,8 +51,18 @@ public class ProblemSetUpdateService {
     public boolean toggleConfirmProblemSet(Long problemSetId) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
 
+        // 문항 유효성 검사
+        for (ProblemId problemId : problemSet.getProblemIds()) {
+            Problem problem = problemRepository.findByIdElseThrow(problemId);
+
+            if (!problem.isValid()) {
+                throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
+            }
+        }
+
         // 현재 상태 반전 (true → false, false → true)
         problemSet.toggleConfirm(!problemSet.isConfirmed());
         return problemSet.isConfirmed();
     }
+
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -52,12 +52,14 @@ public class ProblemSetUpdateService {
     public ProblemSetConfirmStatus toggleConfirmProblemSet(Long problemSetId) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
 
-        // 문항 유효성 검사
-        for (ProblemId problemId : problemSet.getProblemIds()) {
-            Problem problem = problemRepository.findByIdElseThrow(problemId);
+        if(problemSet.getConfirmStatus() == ProblemSetConfirmStatus.NOT_CONFIRMED){
+            // 문항 유효성 검사
+            for (ProblemId problemId : problemSet.getProblemIds()) {
+                Problem problem = problemRepository.findByIdElseThrow(problemId);
 
-            if (!problem.isValid()) {
-                throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
+                if (!problem.isValid()) {
+                    throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
+                }
             }
         }
 

--- a/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
@@ -1,0 +1,37 @@
+package com.moplus.moplus_server.domain.publish.domain;
+
+import com.moplus.moplus_server.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Publish extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "publish_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate publishedDate;
+
+    @Column(name = "problem_set_id", nullable = false)
+    private Long problemSetId;
+
+    @Builder
+    public Publish(LocalDate publishedDate, Long problemSetId) {
+        this.publishedDate = publishedDate;
+        this.problemSetId = problemSetId;
+    }
+
+}

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     PROBLEM_ALREADY_EXIST(HttpStatus.CONFLICT, "해당 문제는 이미 존재합니다"),
     INVALID_MULTIPLE_CHOICE_ANSWER(HttpStatus.BAD_REQUEST, "객관식 문제의 정답은 1~5 사이의 숫자여야 합니다"),
     INVALID_SHORT_NUMBER_ANSWER(HttpStatus.BAD_REQUEST, "주관식 문제의 정답은 0~999 사이의 숫자여야 합니다"),
+    INVALID_CONFIRM_PROBLEM(HttpStatus.BAD_REQUEST, "문항의 모든 요소를 등록해야 컨펌을 완료할 수 있습니다."),
 
     //새끼 문항
     CHILD_PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 새끼 문제를 찾을 수 없습니다"),

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -52,6 +52,9 @@ public enum ErrorCode {
 
     //회원
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다"),
+
+    //문항세트
+    PROBLEM_SET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항세트를 찾을 수 없습니다"),
     ;
 
 

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
@@ -1,0 +1,147 @@
+package com.moplus.moplus_server.domain.problemset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemReorderRequest;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetPostRequest;
+import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRequest;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
+import com.moplus.moplus_server.domain.problemset.service.ProblemSetUpdateService;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("h2test")
+@Sql({"/insert-problemset.sql"})
+@SpringBootTest
+public class ProblemSetServiceTest {
+
+    @Autowired
+    private ProblemSetSaveService problemSetSaveService;
+
+    @Autowired
+    private ProblemSetUpdateService problemSetUpdateService;
+
+    @Autowired
+    private ProblemSetRepository problemSetRepository;
+
+    private ProblemSetPostRequest problemSetPostRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 초기 문항 세트 생성 요청 데이터 준비
+        problemSetPostRequest = new ProblemSetPostRequest(
+                "초기 문항세트",
+                List.of("24052001001", "24052001002", "24052001003")
+        );
+    }
+
+    @Test
+    @Rollback(false)
+    void 문항세트_생성_테스트() {
+        // when
+        Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
+
+        // then
+        ProblemSet savedProblemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new IllegalArgumentException("문항세트를 찾을 수 없습니다."));
+
+        assertThat(savedProblemSet).isNotNull();
+        assertThat(savedProblemSet.getName()).isEqualTo("초기 문항세트");
+        assertThat(savedProblemSet.getProblemIds()).hasSize(3);
+        assertThat(savedProblemSet.getProblemIds().get(0).getId()).isEqualTo("24052001001");
+        assertThat(savedProblemSet.getProblemIds().get(1).getId()).isEqualTo("24052001002");
+        assertThat(savedProblemSet.getProblemIds().get(2).getId()).isEqualTo("24052001003");
+    }
+
+    @Test
+    @Rollback(true)
+    void 문항세트_문항순서_변경_테스트() {
+        // given
+        Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
+
+        // when
+        ProblemReorderRequest reorderRequest = new ProblemReorderRequest(
+                List.of("24052001003", "24052001001", "24052001002")
+        );
+        problemSetUpdateService.reorderProblems(problemSetId, reorderRequest);
+
+        // then
+        ProblemSet updatedProblemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new IllegalArgumentException("문항세트를 찾을 수 없습니다."));
+
+        assertThat(updatedProblemSet.getProblemIds().get(0).getId()).isEqualTo("24052001003");
+        assertThat(updatedProblemSet.getProblemIds().get(1).getId()).isEqualTo("24052001001");
+        assertThat(updatedProblemSet.getProblemIds().get(2).getId()).isEqualTo("24052001002");
+    }
+
+    @Test
+    @Rollback(true)
+    void 문항세트_업데이트_테스트() {
+        // given
+        Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
+
+        // when
+        ProblemSetUpdateRequest updateRequest = new ProblemSetUpdateRequest(
+                "업데이트된 문항세트",
+                List.of("24052001002", "24052001003")
+        );
+        problemSetUpdateService.updateProblemSet(problemSetId, updateRequest);
+
+        // then
+        ProblemSet updatedProblemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new IllegalArgumentException("문항세트를 찾을 수 없습니다."));
+
+        assertThat(updatedProblemSet.getName()).isEqualTo("업데이트된 문항세트");
+        assertThat(updatedProblemSet.getProblemIds()).hasSize(2);
+        assertThat(updatedProblemSet.getProblemIds().get(0).getId()).isEqualTo("24052001002");
+        assertThat(updatedProblemSet.getProblemIds().get(1).getId()).isEqualTo("24052001003");
+    }
+
+    @Test
+    @Rollback(true)
+    void 문항세트_컨펌_토글_테스트() {
+        // given
+        Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
+
+        // when
+        ProblemSetConfirmStatus firstToggleStatus = problemSetUpdateService.toggleConfirmProblemSet(problemSetId); // CONFIRMED
+        ProblemSetConfirmStatus secondToggleStatus = problemSetUpdateService.toggleConfirmProblemSet(problemSetId); // NOT_CONFIRMED
+
+        // then
+        assertThat(firstToggleStatus).isEqualTo(ProblemSetConfirmStatus.CONFIRMED); // 첫 번째 호출 후 컨펌 상태 확인
+        assertThat(secondToggleStatus).isEqualTo(ProblemSetConfirmStatus.NOT_CONFIRMED); // 두 번째 호출 후 비컨펌 상태 확인
+    }
+
+    @Test
+    @Rollback(true)
+    void 유효하지_않은_문항이_포함된_문항세트_컨펌_실패_테스트() {
+        // given
+        Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
+
+        // 유효하지 않은 문항을 포함하도록 설정 (문항 ID가 존재하지 않거나 필수 필드가 누락된 경우)
+        ProblemSetUpdateRequest invalidUpdateRequest = new ProblemSetUpdateRequest(
+                "유효하지 않은 문항세트",
+                List.of("24052001001", "24052001004")
+        );
+        problemSetUpdateService.updateProblemSet(problemSetId, invalidUpdateRequest);
+
+        // when & then
+        assertThatThrownBy(() -> problemSetUpdateService.toggleConfirmProblemSet(problemSetId))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining(ErrorCode.INVALID_CONFIRM_PROBLEM.getMessage());
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
@@ -50,7 +50,7 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(false)
+    @Rollback(true)
     void 문항세트_생성_테스트() {
         // when
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
@@ -50,7 +50,6 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(true)
     void 문항세트_생성_테스트() {
         // when
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
@@ -68,7 +67,6 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(true)
     void 문항세트_문항순서_변경_테스트() {
         // given
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
@@ -89,7 +87,6 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(true)
     void 문항세트_업데이트_테스트() {
         // given
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
@@ -112,7 +109,6 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(true)
     void 문항세트_컨펌_토글_테스트() {
         // given
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);
@@ -127,7 +123,6 @@ public class ProblemSetServiceTest {
     }
 
     @Test
-    @Rollback(true)
     void 유효하지_않은_문항이_포함된_문항세트_컨펌_실패_테스트() {
         // given
         Long problemSetId = problemSetSaveService.createProblemSet(problemSetPostRequest);

--- a/src/test/resources/insert-problemset.sql
+++ b/src/test/resources/insert-problemset.sql
@@ -1,7 +1,9 @@
+DELETE FROM problem_set_problems;
+DELETE FROM problem_set;
+DELETE FROM problem;
 DELETE FROM practice_test_tag;
 DELETE FROM concept_tag;
-DELETE FROM problem;
-DELETE FROM practice_test; -- practice_test 데이터도 삭제
+DELETE FROM practice_test;
 
 -- practice_test 데이터 삽입
 INSERT INTO practice_test (practice_test_id, publication_year, subject, name, provider, round, average_solving_time, solves_count, view_count)

--- a/src/test/resources/insert-problemset.sql
+++ b/src/test/resources/insert-problemset.sql
@@ -35,6 +35,6 @@ VALUES ('24052001001', 1, 1, '1', '기존 문제 설명',
 INSERT INTO problem (problem_id, practice_test_id, number, answer, comment, main_problem_image_url,
                      main_analysis_image_url, reading_tip_image_url, senior_tip_image_url, prescription_image_url,
                      is_published, is_variation)
-VALUES ('24052001004', 1, 4, NULL, '유효하지 않은 문제 설명',
-        NULL, 'mainAnalysis4.png', 'readingTip4.png', 'seniorTip4.png', 'prescription4.png',
+VALUES ('24052001004', 1, 4, '', '유효하지 않은 문제 설명',
+        '', 'mainAnalysis4.png', 'readingTip4.png', 'seniorTip4.png', 'prescription4.png',
         false, false);

--- a/src/test/resources/insert-problemset.sql
+++ b/src/test/resources/insert-problemset.sql
@@ -1,23 +1,11 @@
+DELETE FROM problem_concept;
+DELETE
+FROM child_problem_concept;
+DELETE
+FROM child_problem;
 DELETE FROM problem_set_problems;
 DELETE FROM problem_set;
 DELETE FROM problem;
-DELETE FROM practice_test_tag;
-DELETE FROM concept_tag;
-DELETE FROM practice_test;
-
--- practice_test 데이터 삽입
-INSERT INTO practice_test (practice_test_id, publication_year, subject, name, provider, round, average_solving_time, solves_count, view_count)
-VALUES (1, 2024, '고1', '2024 5월 고1 모의고사', '교육청', '1', 60, 100, 1000);
-
--- practice-test-tag 데이터 삽입
-INSERT INTO practice_test_tag (id, test_year, test_month, subject)
-VALUES (1, 2024, 5, '고1');
-
--- concept-tag 데이터 삽입
-INSERT INTO concept_tag (concept_tag_id, name)
-VALUES (1, '미적분'),
-       (2, '기하'),
-       (3, '확통');
 
 -- problem 데이터 삽입
 INSERT INTO problem (problem_id, practice_test_id, number, answer, comment, main_problem_image_url,

--- a/src/test/resources/insert-problemset.sql
+++ b/src/test/resources/insert-problemset.sql
@@ -1,0 +1,40 @@
+DELETE FROM practice_test_tag;
+DELETE FROM concept_tag;
+DELETE FROM problem;
+DELETE FROM practice_test; -- practice_test 데이터도 삭제
+
+-- practice_test 데이터 삽입
+INSERT INTO practice_test (practice_test_id, publication_year, subject, name, provider, round, average_solving_time, solves_count, view_count)
+VALUES (1, 2024, '고1', '2024 5월 고1 모의고사', '교육청', '1', 60, 100, 1000);
+
+-- practice-test-tag 데이터 삽입
+INSERT INTO practice_test_tag (id, test_year, test_month, subject)
+VALUES (1, 2024, 5, '고1');
+
+-- concept-tag 데이터 삽입
+INSERT INTO concept_tag (concept_tag_id, name)
+VALUES (1, '미적분'),
+       (2, '기하'),
+       (3, '확통');
+
+-- problem 데이터 삽입
+INSERT INTO problem (problem_id, practice_test_id, number, answer, comment, main_problem_image_url,
+                     main_analysis_image_url, reading_tip_image_url, senior_tip_image_url, prescription_image_url,
+                     is_published, is_variation)
+VALUES ('24052001001', 1, 1, '1', '기존 문제 설명',
+        'mainProblem.png', 'mainAnalysis.png', 'readingTip.png', 'seniorTip.png', 'prescription.png',
+        false, false),
+       ('24052001002', 1, 2, '2', '문제 2 설명',
+        'mainProblem2.png', 'mainAnalysis2.png', 'readingTip2.png', 'seniorTip2.png', 'prescription2.png',
+        false, false),
+       ('24052001003', 1, 3, '3', '문제 3 설명',
+        'mainProblem3.png', 'mainAnalysis3.png', 'readingTip3.png', 'seniorTip3.png', 'prescription3.png',
+        false, false);
+
+-- 유효하지 않은 문제 데이터 삽입 (answer와 mainProblemImageUrl이 NULL)
+INSERT INTO problem (problem_id, practice_test_id, number, answer, comment, main_problem_image_url,
+                     main_analysis_image_url, reading_tip_image_url, senior_tip_image_url, prescription_image_url,
+                     is_published, is_variation)
+VALUES ('24052001004', 1, 4, NULL, '유효하지 않은 문제 설명',
+        NULL, 'mainAnalysis4.png', 'readingTip4.png', 'seniorTip4.png', 'prescription4.png',
+        false, false);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #29 

## 📌 작업 내용 및 특이사항
- 다음과 같은 도메인 관계를 생각하며 구현했습니다.

<img width="484" alt="image" src="https://github.com/user-attachments/assets/c1a3b25b-a72e-4ed1-96a6-3e5ca72d81de" />


### 문항과 문항세트 (다대다 관계)
* 문항은 여러 문항세트에 속할 수 있고, 문항 세트 또한 여러 개의 문항을 가지고 있습니다.
* 때문의 DDD 개발론의 ID참조를 통한 단방향 매핑을 통해 구현했습니다.
* String 리스트로 저장을 할까 생각했지만, 문항 Repository가 ProblemId를 기준으로 키값을 관리하기 때문에, ProblemId 리스트로 문항들을 관리하기로 결정했습니다.

### 문항세트와 발행
* 아직 API를 구현해보지 않아서 그럴 수도 있지만, 날짜와 Id 참조를 통한 문항 세트만 존재하는 발행 테이블을 만들면 된다고 생각했습니다.

### 문항세트 수정
https://github.com/team-MoPlus/moplus_server/blob/ffa7cf32e1808386441c8ab9e05ab13ad5c957e3/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java#L38-L50

* 문항세트를 업데이트할 시, 요청으로 받은 문항 ID들이 실제 DB에 있는 값들인지 확인하는 로직을 추가했습니다.

### 문항세트 컨펌

https://github.com/team-MoPlus/moplus_server/blob/ffa7cf32e1808386441c8ab9e05ab13ad5c957e3/src/main/java/com/moplus/moplus_server/domain/problem/domain/problem/Problem.java#L124-L133

* 문항세트를 "컨펌" 상태로 바꾸는 경우에 문항세트 내의 문항들이 유효한지 판단하는 로직을 추가했습니다.

## 📝 테스트 사항
<img width="278" alt="image" src="https://github.com/user-attachments/assets/073c94a8-0a7a-42d7-90dd-5e1ea110d7cc" />

