### PR TITLE
Feature/#42 발행 관련 api 추가

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.domain.problemset.controller;
 
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSetSearchGetResponse;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetSearchRepositoryCustom;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemSetSearchController {
 
     private final ProblemSetSearchRepositoryCustom problemSetSearchRepository;
+    private final PublishRepository publishRepository;
 
     @GetMapping("/search")
     @Operation(
             summary = "문항세트 검색",
-            description = "문항세트 타이틀, 문항세트 내 포함된 개념태그, 문항세트 내 포함된 문항 타이틀로 검색합니다."
+            description = "문항세트 타이틀, 문항세트 내 포함된 개념태그, 문항세트 내 포함된 문항 타이틀로 검색합니다. 발행상태는 발행이면 CONFIRMED, 아니면 NOT_CONFIRMED 입니다."
     )
     public ResponseEntity<List<ProblemSetSearchGetResponse>> search(
             @RequestParam(value = "problemSetTitle", required = false) String problemSetTitle,

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
@@ -3,7 +3,6 @@ package com.moplus.moplus_server.domain.problemset.controller;
 
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSetSearchGetResponse;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetSearchRepositoryCustom;
-import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemSetSearchController {
 
     private final ProblemSetSearchRepositoryCustom problemSetSearchRepository;
-    private final PublishRepository publishRepository;
 
     @GetMapping("/search")
     @Operation(
@@ -32,6 +30,20 @@ public class ProblemSetSearchController {
             @RequestParam(value = "conceptTagNames", required = false) List<String> conceptTagNames
     ) {
         List<ProblemSetSearchGetResponse> problemSets = problemSetSearchRepository.search(problemSetTitle, problemTitle, conceptTagNames);
+        return ResponseEntity.ok(problemSets);
+    }
+
+    @GetMapping("/confirm/search")
+    @Operation(
+            summary = "발행용 문항세트 검색",
+            description = "문항세트 타이틀, 문항세트 내 포함된 개념태그, 문항세트 내 포함된 문항 타이틀로 검색합니다. 발행상태가 CONFIRMED 문항세트만 조회됩니다.."
+    )
+    public ResponseEntity<List<ProblemSetSearchGetResponse>> confirmSearch(
+            @RequestParam(value = "problemSetTitle", required = false) String problemSetTitle,
+            @RequestParam(value = "problemTitle", required = false) String problemTitle,
+            @RequestParam(value = "conceptTagNames", required = false) List<String> conceptTagNames
+    ) {
+        List<ProblemSetSearchGetResponse> problemSets = problemSetSearchRepository.confirmSearch(problemSetTitle, problemTitle, conceptTagNames);
         return ResponseEntity.ok(problemSets);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -65,11 +65,14 @@ public class ProblemSet extends BaseEntity {
 
     public void toggleConfirm(List<Problem> problems) {
         if(this.confirmStatus == ProblemSetConfirmStatus.NOT_CONFIRMED){
-            // 문항 유효성 검사
-            for (Problem problem : problems) {
-                if (!problem.isValid()) {
-                    throw new InvalidValueException(ErrorCode.INVALID_CONFIRM_PROBLEM);
-                }
+            List<String> invalidProblemIds = problems.stream()
+                    .filter(problem -> !problem.isValid())
+                    .map(problem -> problem.getId().getId())
+                    .toList();
+            if (!invalidProblemIds.isEmpty()) {
+                String message = ErrorCode.INVALID_CONFIRM_PROBLEM.getMessage() +
+                        String.join("번 ", invalidProblemIds) + "번";
+                throw new InvalidValueException(message, ErrorCode.INVALID_CONFIRM_PROBLEM);
             }
         }
         this.confirmStatus = this.confirmStatus.toggle();

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemSetGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemSetGetResponse.java
@@ -2,6 +2,7 @@ package com.moplus.moplus_server.domain.problemset.dto.response;
 
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
@@ -10,14 +11,16 @@ public record ProblemSetGetResponse(
         Long id,
         String title,
         ProblemSetConfirmStatus confirmStatus,
+        LocalDate publishedDate,
         List<ProblemSummaryResponse> problemSummaries
 ) {
-    public static ProblemSetGetResponse of(ProblemSet problemSet, List<ProblemSummaryResponse> problemSummaries) {
+    public static ProblemSetGetResponse of(ProblemSet problemSet, LocalDate publishedDate, List<ProblemSummaryResponse> problemSummaries) {
 
         return ProblemSetGetResponse.builder()
                 .id(problemSet.getId())
                 .title(problemSet.getTitle().getValue())
                 .confirmStatus(problemSet.getConfirmStatus())
+                .publishedDate(publishedDate)
                 .problemSummaries(problemSummaries)
                 .build();
     }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemSetSearchGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemSetSearchGetResponse.java
@@ -1,5 +1,7 @@
 package com.moplus.moplus_server.domain.problemset.dto.response;
 
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,12 +10,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProblemSetSearchGetResponse {
     private String problemSetTitle;
+    private ProblemSetConfirmStatus confirmStatus;
+    private LocalDate publishedDate;
     private List<ProblemThumbnailResponse> problemThumbnailResponses;
 
     public ProblemSetSearchGetResponse(
-            String problemSetTitle, List<ProblemThumbnailResponse> problemThumbnailResponses
+            String problemSetTitle, ProblemSetConfirmStatus confirmStatus, LocalDate publishedDate, List<ProblemThumbnailResponse> problemThumbnailResponses
     ) {
         this.problemSetTitle = problemSetTitle;
+        this.confirmStatus = confirmStatus;
+        this.publishedDate = publishedDate;
         this.problemThumbnailResponses = problemThumbnailResponses;
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
@@ -1,6 +1,7 @@
 package com.moplus.moplus_server.domain.problemset.repository;
 
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,11 @@ public interface ProblemSetRepository extends JpaRepository<ProblemSet, Long> {
         return findById(problemSetId).orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_SET_NOT_FOUND));
     }
 
+    default void existsConfirmedActiveByIdElseThrow(Long problemSetId) {
+        if (!existsByIdAndIsDeletedFalseAndConfirmStatus(problemSetId, ProblemSetConfirmStatus.CONFIRMED)) {
+            throw new NotFoundException(ErrorCode.PROBLEM_SET_NOT_FOUND);
+        }
+    }
+
+    boolean existsByIdAndIsDeletedFalseAndConfirmStatus(Long problemSetId, ProblemSetConfirmStatus confirmStatus);
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.domain.problemset.repository;
 import static com.moplus.moplus_server.domain.concept.domain.QConceptTag.conceptTag;
 import static com.moplus.moplus_server.domain.problem.domain.problem.QProblem.problem;
 import static com.moplus.moplus_server.domain.problemset.domain.QProblemSet.problemSet;
+import static com.moplus.moplus_server.domain.publish.domain.QPublish.publish;
 
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSetSearchGetResponse;
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemThumbnailResponse;
@@ -25,6 +26,7 @@ public class ProblemSetSearchRepositoryCustom {
                 .from(problemSet)
                 .leftJoin(problem).on(problem.id.in(problemSet.problemIds)) // 문제 세트 내 포함된 문항과 조인
                 .leftJoin(conceptTag).on(conceptTag.id.in(problem.conceptTagIds)) // 문제의 개념 태그 조인
+                .leftJoin(publish).on(publish.problemSetId.eq(problemSet.id)) // 문제 세트와 발행 데이터 조인
                 .where(
                         containsProblemSetTitle(problemSetTitle),
                         containsProblemTitle(problemTitle),
@@ -34,6 +36,8 @@ public class ProblemSetSearchRepositoryCustom {
                 .transform(GroupBy.groupBy(problemSet.id).list(
                         Projections.constructor(ProblemSetSearchGetResponse.class,
                                 problemSet.title.value,
+                                problemSet.confirmStatus,
+                                publish.publishedDate, // 발행되지 않은 경우 null 반환
                                 GroupBy.list(
                                         Projections.constructor(ProblemThumbnailResponse.class,
                                                 problem.mainProblemImageUrl

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
@@ -11,6 +11,9 @@ import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSetGetResponse;
 import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSummaryResponse;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,11 +28,15 @@ public class ProblemSetGetService {
     private final ProblemRepository problemRepository;
     private final PracticeTestTagRepository practiceTestTagRepository;
     private final ConceptTagRepository conceptTagRepository;
+    private final PublishRepository publishRepository;
 
     @Transactional(readOnly = true)
     public ProblemSetGetResponse getProblemSet(Long problemSetId) {
 
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+        LocalDate publishedDate = publishRepository.findByProblemSetId(problemSetId)
+                .map(Publish::getPublishedDate)
+                .orElse(null);
 
         List<ProblemSummaryResponse> problemSummaries = new ArrayList<>();
         for (ProblemId problemId : problemSet.getProblemIds()) {
@@ -41,6 +48,6 @@ public class ProblemSetGetService {
                     .toList();
             problemSummaries.add(ProblemSummaryResponse.of(problem, practiceTestTag.getName(), tagNames));
         }
-        return ProblemSetGetResponse.of(problemSet, problemSummaries);
+        return ProblemSetGetResponse.of(problemSet, publishedDate, problemSummaries);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/controller/PublishController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/controller/PublishController.java
@@ -1,0 +1,54 @@
+package com.moplus.moplus_server.domain.publish.controller;
+
+import com.moplus.moplus_server.domain.publish.dto.request.PublishPostRequest;
+import com.moplus.moplus_server.domain.publish.dto.response.PublishMonthGetResponse;
+import com.moplus.moplus_server.domain.publish.service.PublishDeleteService;
+import com.moplus.moplus_server.domain.publish.service.PublishGetService;
+import com.moplus.moplus_server.domain.publish.service.PublishSaveService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/publish")
+@RequiredArgsConstructor
+public class PublishController {
+
+    private final PublishGetService publishGetService;
+    private final PublishSaveService publishSaveService;
+    private final PublishDeleteService publishDeleteService;
+
+    @GetMapping("/{year}/{month}")
+    @Operation(summary = "연월별 발행 조회", description = "연월별로 발행된 세트들을 조회합니다.")
+    public ResponseEntity<List<PublishMonthGetResponse>> getPublishMonth(
+            @PathVariable int year,
+            @PathVariable int month
+    ) {
+        return ResponseEntity.ok(publishGetService.getPublishMonth(year, month));
+    }
+
+    @PostMapping("")
+    @Operation(summary = "발행 생성하기", description = "특정 날짜에 문항세트를 발행합니다.")
+    public ResponseEntity<Long> postPublish(
+            @RequestBody PublishPostRequest request
+    ) {
+        return ResponseEntity.ok(publishSaveService.createPublish(request));
+    }
+
+    @DeleteMapping("/{publishId}")
+    @Operation(summary = "발행 삭제", description = "발행을 삭제합니다.")
+    public ResponseEntity<Void> deleteProblemSet(
+            @PathVariable Long publishId
+    ) {
+        publishDeleteService.deletePublish(publishId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
@@ -1,6 +1,8 @@
 package com.moplus.moplus_server.domain.publish.domain;
 
 import com.moplus.moplus_server.global.common.BaseEntity;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,4 +36,10 @@ public class Publish extends BaseEntity {
         this.problemSetId = problemSetId;
     }
 
+    public void validatePublishedDate() {
+        // 발행 시점 다음날부터 발행 가능
+        if (this.publishedDate.isBefore(LocalDate.now().plusDays(1))) {
+            throw new InvalidValueException(ErrorCode.INVALID_DATE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
@@ -1,29 +1,16 @@
 package com.moplus.moplus_server.domain.publish.dto.request;
 
 import com.moplus.moplus_server.domain.publish.domain.Publish;
-import com.moplus.moplus_server.global.error.exception.ErrorCode;
-import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import java.time.LocalDate;
 
 public record PublishPostRequest(
         LocalDate publishedDate,
         Long problemSetId
 ) {
-    public PublishPostRequest {
-        validatePublishedDate(publishedDate);
-    }
-
     public Publish toEntity() {
         return Publish.builder()
                 .publishedDate(this.publishedDate)
                 .problemSetId(this.problemSetId)
                 .build();
-    }
-
-    private static void validatePublishedDate(LocalDate publishedDate) {
-        // 발행 시점 다음날부터 발행 가능
-        if (publishedDate.isBefore(LocalDate.now().plusDays(1))) {
-            throw new InvalidValueException(ErrorCode.INVALID_DATE_ERROR);
-        }
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
@@ -1,0 +1,29 @@
+package com.moplus.moplus_server.domain.publish.dto.request;
+
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.time.LocalDate;
+
+public record PublishPostRequest(
+        LocalDate publishedDate,
+        Long problemSetId
+) {
+    public PublishPostRequest {
+        validatePublishedDate(publishedDate);
+    }
+
+    public Publish toEntity() {
+        return Publish.builder()
+                .publishedDate(this.publishedDate)
+                .problemSetId(this.problemSetId)
+                .build();
+    }
+
+    private static void validatePublishedDate(LocalDate publishedDate) {
+        // 발행 시점 다음날부터 발행 가능
+        if (publishedDate.isBefore(LocalDate.now().plusDays(1))) {
+            throw new InvalidValueException(ErrorCode.INVALID_DATE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishMonthGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishMonthGetResponse.java
@@ -1,0 +1,17 @@
+package com.moplus.moplus_server.domain.publish.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PublishMonthGetResponse(
+        int day,
+        PublishProblemSetResponse problemSetInfo
+) {
+    public static PublishMonthGetResponse of(int day, PublishProblemSetResponse problemSetInfos) {
+
+        return PublishMonthGetResponse.builder()
+                .day(day)
+                .problemSetInfo(problemSetInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishProblemSetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishProblemSetResponse.java
@@ -1,0 +1,18 @@
+package com.moplus.moplus_server.domain.publish.dto.response;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import lombok.Builder;
+
+@Builder
+public record PublishProblemSetResponse(
+        Long id,
+        String title
+) {
+    public static PublishProblemSetResponse of(ProblemSet problemSet) {
+
+        return PublishProblemSetResponse.builder()
+                .id(problemSet.getId())
+                .title(problemSet.getTitle().getValue())
+                .build();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
@@ -1,0 +1,16 @@
+package com.moplus.moplus_server.domain.publish.repository;
+
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PublishRepository extends JpaRepository<Publish, Long> {
+    List<Publish> findByPublishedDateBetween(LocalDate startDate, LocalDate endDate);
+
+    default Publish findByIdElseThrow(Long publishId) {
+        return findById(publishId).orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISH_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/repository/PublishRepository.java
@@ -5,6 +5,7 @@ import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PublishRepository extends JpaRepository<Publish, Long> {
@@ -13,4 +14,6 @@ public interface PublishRepository extends JpaRepository<Publish, Long> {
     default Publish findByIdElseThrow(Long publishId) {
         return findById(publishId).orElseThrow(() -> new NotFoundException(ErrorCode.PUBLISH_NOT_FOUND));
     }
+
+    Optional<Publish> findByProblemSetId(Long problemSetId);
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishDeleteService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishDeleteService.java
@@ -1,0 +1,20 @@
+package com.moplus.moplus_server.domain.publish.service;
+
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublishDeleteService {
+
+    private final PublishRepository publishRepository;
+
+    @Transactional
+    public void deletePublish(Long publishId) {
+        Publish publish = publishRepository.findByIdElseThrow(publishId);
+        publishRepository.delete(publish);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishGetService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishGetService.java
@@ -1,0 +1,49 @@
+package com.moplus.moplus_server.domain.publish.service;
+
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.domain.publish.dto.response.PublishMonthGetResponse;
+import com.moplus.moplus_server.domain.publish.dto.response.PublishProblemSetResponse;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublishGetService {
+
+    private final PublishRepository publishRepository;
+    private final ProblemSetRepository problemSetRepository;
+
+    @Transactional(readOnly = true)
+    public List<PublishMonthGetResponse> getPublishMonth(int year, int month) {
+        if (month < 1 || month > 12) {
+            throw new InvalidValueException(ErrorCode.INVALID_MONTH_ERROR);
+        }
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        // 주어진 월에 해당하는 모든 Publish 조회
+        List<Publish> publishes = publishRepository.findByPublishedDateBetween(startDate, endDate);
+
+        // 데이터를 day 기준으로 매핑
+        return publishes.stream()
+                .map(publish -> {
+                    ProblemSet problemSet = problemSetRepository.findByIdElseThrow(publish.getProblemSetId());
+                    PublishProblemSetResponse problemSetResponse = PublishProblemSetResponse.of(problemSet);
+
+                    return PublishMonthGetResponse.of(
+                            publish.getPublishedDate().getDayOfMonth(),
+                            problemSetResponse
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
@@ -19,6 +19,8 @@ public class PublishSaveService {
     public Long createPublish(PublishPostRequest request) {
         problemSetRepository.existsConfirmedActiveByIdElseThrow(request.problemSetId());
         Publish publish = request.toEntity();
+        // 발행날짜 유효성 검사
+        publish.validatePublishedDate();
         return publishRepository.save(publish).getId();
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
@@ -1,0 +1,24 @@
+package com.moplus.moplus_server.domain.publish.service;
+
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.domain.publish.dto.request.PublishPostRequest;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PublishSaveService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final PublishRepository publishRepository;
+
+    @Transactional
+    public Long createPublish(PublishPostRequest request) {
+        problemSetRepository.existsConfirmedActiveByIdElseThrow(request.problemSetId());
+        Publish publish = request.toEntity();
+        return publishRepository.save(publish).getId();
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     PROBLEM_ALREADY_EXIST(HttpStatus.CONFLICT, "해당 문제는 이미 존재합니다"),
     INVALID_MULTIPLE_CHOICE_ANSWER(HttpStatus.BAD_REQUEST, "객관식 문제의 정답은 1~5 사이의 숫자여야 합니다"),
     INVALID_SHORT_NUMBER_ANSWER(HttpStatus.BAD_REQUEST, "주관식 문제의 정답은 0~999 사이의 숫자여야 합니다"),
-    INVALID_CONFIRM_PROBLEM(HttpStatus.BAD_REQUEST, "문항의 모든 요소를 등록해야 컨펌을 완료할 수 있습니다."),
+    INVALID_CONFIRM_PROBLEM(HttpStatus.BAD_REQUEST, "유효하지 않은 문항들 : "),
 
     //새끼 문항
     CHILD_PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 새끼 문제를 찾을 수 없습니다"),

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -57,6 +57,11 @@ public enum ErrorCode {
     //문항세트
     PROBLEM_SET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항세트를 찾을 수 없습니다"),
     EMPTY_PROBLEMS_ERROR(HttpStatus.BAD_REQUEST, "적어도 1개의 문항을 등록해주세요"),
+
+    // 발행
+    INVALID_MONTH_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 월입니다."),
+    INVALID_DATE_ERROR(HttpStatus.BAD_REQUEST, "오늘 이후 날짜에만 발행이 가능합니다."),
+    PUBLISH_NOT_FOUND(HttpStatus.NOT_FOUND, "발행 정보를 찾을 수 없습니다"),
     ;
 
 

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
@@ -135,6 +135,7 @@ public class ProblemSetServiceTest {
         // when & then
         assertThatThrownBy(() -> problemSetUpdateService.toggleConfirmProblemSet(problemSetId))
                 .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining("24052001004번") // 메시지에 포함된 ID 확인
                 .hasMessageContaining(ErrorCode.INVALID_CONFIRM_PROBLEM.getMessage());
     }
 

--- a/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
@@ -1,0 +1,129 @@
+package com.moplus.moplus_server.domain.publish.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.moplus.moplus_server.domain.publish.domain.Publish;
+import com.moplus.moplus_server.domain.publish.dto.request.PublishPostRequest;
+import com.moplus.moplus_server.domain.publish.dto.response.PublishMonthGetResponse;
+import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("h2test")
+@Sql({"/insert-problem.sql", "/insert-problem-set2.sql"})
+@SpringBootTest
+public class PublishServiceTest {
+
+    @Autowired
+    private PublishSaveService publishSaveService;
+
+    @Autowired
+    private PublishDeleteService publishDeleteService;
+
+    @Autowired
+    private PublishGetService publishGetService;
+
+    @Autowired
+    private PublishRepository publishRepository;
+
+    private PublishPostRequest publishPostRequest;
+
+    @BeforeEach
+    void setUp() {
+        // 발행 요청 데이터 생성
+        publishPostRequest = new PublishPostRequest(
+                LocalDate.now().plusDays(1), // 내일부터 발행 가능
+                1L
+        );
+    }
+
+    @Test
+    void 발행_생성_테스트() {
+        // when
+        Long publishId = publishSaveService.createPublish(publishPostRequest);
+
+        // then
+        Publish savedPublish = publishRepository.findByIdElseThrow(publishId);
+
+        assertThat(savedPublish).isNotNull();
+        assertThat(savedPublish.getPublishedDate()).isEqualTo(publishPostRequest.publishedDate());
+        assertThat(savedPublish.getProblemSetId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 발행_삭제_테스트() {
+        // given
+        Long publishId = publishSaveService.createPublish(publishPostRequest);
+
+        // when
+        publishDeleteService.deletePublish(publishId);
+
+        // then
+        assertThatThrownBy(() -> publishRepository.findByIdElseThrow(publishId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ErrorCode.PUBLISH_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 월별_발행_조회_테스트() {
+        // given
+        publishSaveService.createPublish(new PublishPostRequest(
+                LocalDate.of(2025, 2, 10),
+                1L
+        ));
+
+        publishSaveService.createPublish(new PublishPostRequest(
+                LocalDate.of(2025, 2, 15),
+                1L
+        ));
+
+        // when
+        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(2025, 2);
+
+        // then
+        assertThat(publishList).hasSize(2);
+        assertThat(publishList.get(0).day()).isEqualTo(10);
+        assertThat(publishList.get(0).problemSetInfo().title()).isEqualTo("2025년 5월 고2 모의고사 문제 세트");
+        assertThat(publishList.get(1).day()).isEqualTo(15);
+    }
+
+    @Test
+    void 유효하지_않은_월_입력시_예외_테스트() {
+        // when & then
+        assertThatThrownBy(() -> publishGetService.getPublishMonth(2025, 13))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining(ErrorCode.INVALID_MONTH_ERROR.getMessage());
+
+        assertThatThrownBy(() -> publishGetService.getPublishMonth(2025, 0))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining(ErrorCode.INVALID_MONTH_ERROR.getMessage());
+    }
+
+    @Test
+    void 오늘날짜_또는_과거날짜로_발행_시_예외_테스트() {
+        // given
+        LocalDate today = LocalDate.now();
+        LocalDate pastDate = today.minusDays(1);
+
+        // when & then (createPublish에서 예외 발생하도록)
+        assertThatThrownBy(() -> publishSaveService.createPublish(new PublishPostRequest(today, 1L)))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining(ErrorCode.INVALID_DATE_ERROR.getMessage());
+
+        assertThatThrownBy(() -> publishSaveService.createPublish(new PublishPostRequest(pastDate, 1L)))
+                .isInstanceOf(InvalidValueException.class)
+                .hasMessageContaining(ErrorCode.INVALID_DATE_ERROR.getMessage());
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
@@ -80,17 +80,17 @@ public class PublishServiceTest {
     void 월별_발행_조회_테스트() {
         // given
         publishSaveService.createPublish(new PublishPostRequest(
-                LocalDate.of(2025, 2, 10),
+                LocalDate.of(2025, 3, 10),
                 1L
         ));
 
         publishSaveService.createPublish(new PublishPostRequest(
-                LocalDate.of(2025, 2, 15),
+                LocalDate.of(2025, 3, 15),
                 1L
         ));
 
         // when
-        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(2025, 2);
+        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(2025, 3);
 
         // then
         assertThat(publishList).hasSize(2);

--- a/src/test/resources/insert-problem-set.sql
+++ b/src/test/resources/insert-problem-set.sql
@@ -4,8 +4,13 @@ DELETE FROM problem_set;
 -- 문제 세트 추가
 INSERT INTO problem_set (problem_set_id, title, is_deleted, confirm_status)
 VALUES (1, '2025년 5월 고2 모의고사 문제 세트', false, 'NOT_CONFIRMED');
+INSERT INTO problem_set (problem_set_id, title, is_deleted, confirm_status)
+VALUES (2, '2025년 5월 고3 모의고사 문제 세트', false, 'CONFIRMED');
 
 -- 문제 세트에 포함된 문제 추가
 INSERT INTO problem_set_problems (problem_set_id, problem_id, sequence)
 VALUES (1, '240520012001', 0),
        (1, '240520012002', 1);
+INSERT INTO problem_set_problems (problem_set_id, problem_id, sequence)
+VALUES (2, '240520012001', 0),
+       (2, '240520012002', 1);

--- a/src/test/resources/insert-problem-set2.sql
+++ b/src/test/resources/insert-problem-set2.sql
@@ -1,0 +1,11 @@
+DELETE FROM problem_set_problems;
+DELETE FROM problem_set;
+
+-- 문제 세트 추가
+INSERT INTO problem_set (problem_set_id, title, is_deleted, confirm_status)
+VALUES (1, '2025년 5월 고2 모의고사 문제 세트', false, 'CONFIRMED');
+
+-- 문제 세트에 포함된 문제 추가
+INSERT INTO problem_set_problems (problem_set_id, problem_id, sequence)
+VALUES (1, '240520012001', 0),
+       (1, '240520012002', 1);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #42 

## 📌 작업 내용 및 특이사항
* 발행과 관련된 api들을 구현했습니다.
* 발행 생성 시 컨펌이 완료된 세트, 존재하는 세트, 삭제되지 않은 세트들만 발행되도록 구현했습니다.
* 발행 날짜는 발행하는 시점을 기준으로 다음날부터만 가능하도록 했습니다.
* 발행은 삭제하고, 다시 세트를 등록하는 플로우로 이해하고 수정은 구현하지 않고, 삭제 시 디비에서 바로 삭제되도록 했습니다.

* 문항세트 컨펌 시 유효하지 않은 문항이 포함되어 있다면, 해당 문항ID들을 에러메시지에 담아 출력해주었습니다.
* 문항세트 조회 시(개별 조회, 검색) 발행 유무와, 발행되었다면 발행날짜를 포함하여 조회되도록 수정했습니다.
