### PR TITLE
Feature/#47 문항세트 검색 시 문항타이틀, 문항메모 필드 추가

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -35,15 +35,17 @@ public class ProblemSet extends BaseEntity {
 
     @Embedded
     private Title title;
+    @Column(nullable = false)
     private boolean isDeleted;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ProblemSetConfirmStatus confirmStatus;
 
     @ElementCollection
     @CollectionTable(name = "problem_set_problems", joinColumns = @JoinColumn(name = "problem_set_id"))
-    @Column(name = "problem_id")
     @OrderColumn(name = "sequence")
+    @Column(name = "problem_id", nullable = false)
     private List<Long> problemIds = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemThumbnailResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/dto/response/ProblemThumbnailResponse.java
@@ -6,9 +6,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ProblemThumbnailResponse {
+    private String problemTitle;
+    private String problemMemo;
     private String mainProblemImageUrl;
 
-    public ProblemThumbnailResponse(String mainProblemImageUrl) {
+    public ProblemThumbnailResponse(String problemTitle, String problemMemo, String mainProblemImageUrl) {
+        this.problemTitle = problemTitle;
+        this.problemMemo = problemMemo;
         this.mainProblemImageUrl = mainProblemImageUrl;
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
@@ -42,6 +42,8 @@ public class ProblemSetSearchRepositoryCustom {
                                 publish.publishedDate, // 발행되지 않은 경우 null 반환
                                 GroupBy.list(
                                         Projections.constructor(ProblemThumbnailResponse.class,
+                                                problem.title.title,
+                                                problem.memo,
                                                 problem.mainProblemImageUrl
                                         )
                                 )
@@ -70,6 +72,8 @@ public class ProblemSetSearchRepositoryCustom {
                                 publish.publishedDate, // 발행되지 않은 경우 null 반환
                                 GroupBy.list(
                                         Projections.constructor(ProblemThumbnailResponse.class,
+                                                problem.title.title,
+                                                problem.memo,
                                                 problem.mainProblemImageUrl
                                         )
                                 )

--- a/src/main/java/com/moplus/moplus_server/domain/publish/controller/PublishController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/controller/PublishController.java
@@ -7,6 +7,7 @@ import com.moplus.moplus_server.domain.publish.service.PublishGetService;
 import com.moplus.moplus_server.domain.publish.service.PublishSaveService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +41,7 @@ public class PublishController {
     @PostMapping("")
     @Operation(summary = "발행 생성하기", description = "특정 날짜에 문항세트를 발행합니다.")
     public ResponseEntity<Long> postPublish(
-            @RequestBody PublishPostRequest request
+            @Valid @RequestBody PublishPostRequest request
     ) {
         return ResponseEntity.ok(publishSaveService.createPublish(request));
     }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/request/PublishPostRequest.java
@@ -1,10 +1,13 @@
 package com.moplus.moplus_server.domain.publish.dto.request;
 
 import com.moplus.moplus_server.domain.publish.domain.Publish;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record PublishPostRequest(
+        @NotNull
         LocalDate publishedDate,
+        @NotNull
         Long problemSetId
 ) {
     public Publish toEntity() {

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustomTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustomTest.java
@@ -98,8 +98,13 @@ public class ProblemSetSearchRepositoryCustomTest {
         List<ProblemThumbnailResponse> problems = response.getProblemThumbnailResponses();
         assertThat(problems).hasSize(2);
 
-        // ✅ 문항의 이미지 URL이 올바르게 매핑되었는지 확인
+        // ✅ 문항의 타이틀, 메모, 이미지 URL이 올바르게 매핑되었는지 확인
+        assertThat(problems.get(0).getProblemTitle()).isEqualTo("제목1");
+        assertThat(problems.get(0).getProblemMemo()).isEqualTo("기존 문제 설명 1");
         assertThat(problems.get(0).getMainProblemImageUrl()).isEqualTo("mainProblem.png1");
+
+        assertThat(problems.get(1).getProblemTitle()).isEqualTo("제목2");
+        assertThat(problems.get(1).getProblemMemo()).isEqualTo("기존 문제 설명 2");
         assertThat(problems.get(1).getMainProblemImageUrl()).isEqualTo("mainProblem.png2");
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #47 

## 📌 작업 내용 및 특이사항
- 추가된 문항 필드에 따라, 문항세트 검색시 문항타이틀, 문항메모 필드를 추가했습니다.
- Null값이 오면 안되는 필드에 대한 유효성검사를 추가했습니다.