### PR TITLE
Hotfix/#55 문항세트, 발행 문제 해결

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/controller/ProblemSetSearchController.java
@@ -28,11 +28,9 @@ public class ProblemSetSearchController {
     )
     public ResponseEntity<List<ProblemSetSearchGetResponse>> search(
             @RequestParam(value = "problemSetTitle", required = false) String problemSetTitle,
-            @RequestParam(value = "problemTitle", required = false) String problemTitle,
-            @RequestParam(value = "conceptTagNames", required = false) List<String> conceptTagNames
+            @RequestParam(value = "problemTitle", required = false) String problemTitle
     ) {
-        List<ProblemSetSearchGetResponse> problemSets = problemSetSearchRepository.search(problemSetTitle, problemTitle,
-                conceptTagNames);
+        List<ProblemSetSearchGetResponse> problemSets = problemSetSearchRepository.search(problemSetTitle, problemTitle);
         return ResponseEntity.ok(problemSets);
     }
 
@@ -44,11 +42,10 @@ public class ProblemSetSearchController {
     )
     public ResponseEntity<List<ProblemSetSearchGetResponse>> confirmSearch(
             @RequestParam(value = "problemSetTitle", required = false) String problemSetTitle,
-            @RequestParam(value = "problemTitle", required = false) String problemTitle,
-            @RequestParam(value = "conceptTagNames", required = false) List<String> conceptTagNames
+            @RequestParam(value = "problemTitle", required = false) String problemTitle
     ) {
         List<ProblemSetSearchGetResponse> problemSets = problemSetSearchRepository.confirmSearch(problemSetTitle,
-                problemTitle, conceptTagNames);
+                problemTitle);
         return ResponseEntity.ok(problemSets);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
@@ -22,8 +22,7 @@ public class ProblemSetSearchRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<ProblemSetSearchGetResponse> search(String problemSetTitle, String problemTitle,
-                                                    List<String> conceptTagNames) {
+    public List<ProblemSetSearchGetResponse> search(String problemSetTitle, String problemTitle) {
         return queryFactory
                 .from(problemSet)
                 .leftJoin(problem).on(problem.id.in(problemSet.problemIds)) // 문제 세트 내 포함된 문항과 조인
@@ -31,8 +30,7 @@ public class ProblemSetSearchRepositoryCustom {
                 .leftJoin(publish).on(publish.problemSetId.eq(problemSet.id)) // 문제 세트와 발행 데이터 조인
                 .where(
                         containsProblemSetTitle(problemSetTitle),
-                        containsProblemTitle(problemTitle),
-                        containsConceptTagNames(conceptTagNames)
+                        containsProblemTitle(problemTitle)
                 )
                 .distinct()
                 .transform(GroupBy.groupBy(problemSet.id).list(
@@ -51,8 +49,7 @@ public class ProblemSetSearchRepositoryCustom {
                 ));
     }
 
-    public List<ProblemSetSearchGetResponse> confirmSearch(String problemSetTitle, String problemTitle,
-                                                           List<String> conceptTagNames) {
+    public List<ProblemSetSearchGetResponse> confirmSearch(String problemSetTitle, String problemTitle) {
         return queryFactory
                 .from(problemSet)
                 .leftJoin(problem).on(problem.id.in(problemSet.problemIds)) // 문제 세트 내 포함된 문항과 조인
@@ -61,8 +58,7 @@ public class ProblemSetSearchRepositoryCustom {
                 .where(
                         problemSet.confirmStatus.eq(CONFIRMED),
                         containsProblemSetTitle(problemSetTitle),
-                        containsProblemTitle(problemTitle),
-                        containsConceptTagNames(conceptTagNames)
+                        containsProblemTitle(problemTitle)
                 )
                 .distinct()
                 .transform(GroupBy.groupBy(problemSet.id).list(
@@ -88,9 +84,5 @@ public class ProblemSetSearchRepositoryCustom {
 
     private BooleanExpression containsProblemTitle(String problemTitle) {
         return (problemTitle == null || problemTitle.isEmpty()) ? null : problem.memo.containsIgnoreCase(problemTitle);
-    }
-
-    private BooleanExpression containsConceptTagNames(List<String> conceptTagNames) {
-        return (conceptTagNames == null || conceptTagNames.isEmpty()) ? null : conceptTag.name.in(conceptTagNames);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/global/response/ResponseDto.java
+++ b/src/main/java/com/moplus/moplus_server/global/response/ResponseDto.java
@@ -1,0 +1,20 @@
+package com.moplus.moplus_server.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.moplus.moplus_server.global.error.ErrorResponse;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseDto<T>(
+        T data,
+        String message,
+        HttpStatus status
+) {
+    public static <T> ResponseDto<T> success(final T data) {
+        return new ResponseDto<>(data, null, null);
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorResponse errorResponse) {
+        return new ResponseDto<>(null, errorResponse.getMessage(), errorResponse.getStatus());
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/response/ResponseDtoAdvice.java
+++ b/src/main/java/com/moplus/moplus_server/global/response/ResponseDtoAdvice.java
@@ -1,0 +1,39 @@
+package com.moplus.moplus_server.global.response;
+
+import com.moplus.moplus_server.global.error.ErrorResponse;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(
+        basePackages = "com.moplus.moplus_server"
+)
+
+public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return !(returnType.getParameterType() == ResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response
+    ) {
+        if (body instanceof ErrorResponse) {
+            return ResponseDto.fail((ErrorResponse) body);
+        }
+        return ResponseDto.success(body);
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/member/controller/MemberControllerTest.java
@@ -70,9 +70,9 @@ class MemberControllerTest {
                             .contentType("application/json")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken))
                     .andExpect(status().isOk()) // 200 응답 확인
-                    .andExpect(jsonPath("$.id").exists()) // MemberGetResponse의 필드 확인
-                    .andExpect(jsonPath("$.name").exists())
-                    .andExpect(jsonPath("$.email").exists());
+                    .andExpect(jsonPath("$.data.id").exists()) // MemberGetResponse의 필드 확인
+                    .andExpect(jsonPath("$.data.name").exists())
+                    .andExpect(jsonPath("$.data.email").exists());
         }
     }
 }

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustomTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustomTest.java
@@ -36,7 +36,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 문항세트_타이틀_일부_포함_검색() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null, null);
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null);
 
         // then
         assertThat(result).hasSize(1);
@@ -46,18 +46,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 문항타이틀_포함_검색() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search(null, "설명", null);
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getProblemSetTitle()).isEqualTo("2025년 5월 고2 모의고사 문제 세트");
-        assertThat(result.get(1).getProblemSetTitle()).isEqualTo("2025년 5월 고3 모의고사 문제 세트");
-    }
-
-    @Test
-    void 개념태그_하나라도_포함되면_조회() {
-        // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search(null, null, List.of("미분 개념"));
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search(null, "설명");
 
         // then
         assertThat(result).hasSize(2);
@@ -68,7 +57,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 모두_적용된_검색() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2", "설명 1", List.of("미분 개념"));
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2", "설명 1");
 
         // then
         assertThat(result).hasSize(1);
@@ -78,7 +67,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 아무_조건도_없으면_모든_데이터_조회() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search(null, null, null);
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search(null, null);
 
         // then
         assertThat(result).hasSize(2);
@@ -87,7 +76,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 문항_여러개_문항세트_검색_조회() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null, null);
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null);
 
         // then
         assertThat(result).hasSize(1);
@@ -111,7 +100,7 @@ public class ProblemSetSearchRepositoryCustomTest {
     @Test
     void 발행되지_않은_문항세트는_NOT_CONFIRMED_테스트() {
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null, null);
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고2 모의고사", null);
 
         // then
         assertThat(result).hasSize(1);
@@ -128,7 +117,7 @@ public class ProblemSetSearchRepositoryCustomTest {
         publishSaveService.createPublish(new PublishPostRequest(publishDate, 2L));
 
         // when
-        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고3 모의고사", null, null);
+        List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.search("고3 모의고사", null);
 
         // then
         assertThat(result).hasSize(1);
@@ -146,8 +135,7 @@ public class ProblemSetSearchRepositoryCustomTest {
         // when: publishSearch 실행 (CONFIRMED 상태만 검색되어야 함)
         List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.confirmSearch(
                 "고",
-                "설명",
-                List.of("미분 개념")
+                "설명"
         );
 
         // then
@@ -165,7 +153,6 @@ public class ProblemSetSearchRepositoryCustomTest {
         // when: 발행된 문제 세트만 조회하는 publishSearch 실행
         List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.confirmSearch(
                 null,
-                null,
                 null
         );
 
@@ -182,7 +169,6 @@ public class ProblemSetSearchRepositoryCustomTest {
         // when
         List<ProblemSetSearchGetResponse> result = problemSetSearchRepository.confirmSearch(
                 "고3 모의고사",
-                null,
                 null
         );
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #55

## 📌 작업 내용 및 특이사항
### 필드가 없는 응답(json 형식이 아닌 long타입이나 String 타입)
* 필드 없이 값만 body에 넣어 내려오는 응답들을 json형식으로 감싸주기 위해 어드바이스를 추가했습니다.
* ResponseBodyAdvice를 활용하여 모든 응답을 ResponseDto<T> 형식으로 감싸도록 설정했습니다.
* 기존 ErrorResponse 타입의 응답은 fail 함수로 변환해줍니다.
* 결과적으로 모든 성공 응답에 data필드가 추가되었고, 실패 응답은 동일한 형태입니다.

### 문항세트 검색
* 문항세트 검색 시 (목록용, 발행용) 개념태그 검색은 삭제했습니다.
* 문항세트 타이틀, 포함된 문항 타이틀로만 검색되도록 변경했습니다.