### PR TITLE
[feat/#57] 공통응답 스웨거 스키마 반영

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problem/dto/response/PresignedUrlResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problem/dto/response/PresignedUrlResponse.java
@@ -1,7 +1,7 @@
 package com.moplus.moplus_server.domain.problem.dto.response;
 
 public record PresignedUrlResponse(
-        String data
+        String presignedUrl
 ) {
     public static PresignedUrlResponse of(String presignedUrl) {
         return new PresignedUrlResponse(

--- a/src/main/java/com/moplus/moplus_server/global/response/ResponseDto.java
+++ b/src/main/java/com/moplus/moplus_server/global/response/ResponseDto.java
@@ -1,0 +1,20 @@
+package com.moplus.moplus_server.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.moplus.moplus_server.global.error.ErrorResponse;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseDto<T>(
+        T data,
+        String message,
+        HttpStatus status
+) {
+    public static <T> ResponseDto<T> success(final T data) {
+        return new ResponseDto<>(data, null, null);
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorResponse errorResponse) {
+        return new ResponseDto<>(null, errorResponse.getMessage(), errorResponse.getStatus());
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/global/response/ResponseDtoAdvice.java
+++ b/src/main/java/com/moplus/moplus_server/global/response/ResponseDtoAdvice.java
@@ -1,0 +1,38 @@
+package com.moplus.moplus_server.global.response;
+
+import com.moplus.moplus_server.global.error.ErrorResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(
+        basePackages = "com.moplus.moplus_server"
+)
+
+public class ResponseDtoAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return !(returnType.getParameterType() == ResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response
+    ) {
+        if (body instanceof ErrorResponse) {
+            return ResponseDto.fail((ErrorResponse) body);
+        }
+        return ResponseDto.success(body);
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/member/controller/MemberControllerTest.java
@@ -70,9 +70,9 @@ class MemberControllerTest {
                             .contentType("application/json")
                             .header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken))
                     .andExpect(status().isOk()) // 200 응답 확인
-                    .andExpect(jsonPath("$.id").exists()) // MemberGetResponse의 필드 확인
-                    .andExpect(jsonPath("$.name").exists())
-                    .andExpect(jsonPath("$.email").exists());
+                    .andExpect(jsonPath("$.data.id").exists()) // MemberGetResponse의 필드 확인
+                    .andExpect(jsonPath("$.data.name").exists())
+                    .andExpect(jsonPath("$.data.email").exists());
         }
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #57 

## 📌 작업 내용 및 특이사항
- ResponseAdvice와 Swagger를 함께 사용할 때, 스키마에 공통 응답이 반영되지 않던 오류를 해결했습니다.
- springdoc의 OperationCustomizer를 빈으로 등록하여 스키마 Json형식을 직접 수정했습니다.

## 📝 참고사항
- ResponseAdvice가 봉투패턴으로 감싸주는 것은 String을 제외한 객체들입니다.
- String은 MappingJackson2HttpMessageConverter 클래스로 변환되지 않고, 그대로 body에 들어가기 때문에, 만약 String으로 응답을 해야하는 api는 별도의 dto를 적용해주어야 합니다.
