### PR TITLE
Fix/#77 발행 이슈 해결

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -74,6 +74,9 @@ public class ProblemSet extends BaseEntity {
 
     public void toggleConfirm(List<Problem> problems) {
         if (this.confirmStatus == ProblemSetConfirmStatus.NOT_CONFIRMED) {
+            if (problems.isEmpty()) {
+                throw new InvalidValueException(ErrorCode.EMPTY_PROBLEMS_ERROR);
+            }
             List<String> invalidProblemIds = problems.stream()
                     .filter(problem -> !problem.isValid())
                     .map(Problem::getProblemCustomId)

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/domain/ProblemSet.java
@@ -4,6 +4,7 @@ import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
 import com.moplus.moplus_server.global.common.BaseEntity;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import com.moplus.moplus_server.global.error.exception.ProblemSetToggleException;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -84,7 +85,7 @@ public class ProblemSet extends BaseEntity {
             if (!invalidProblemIds.isEmpty()) {
                 String message = ErrorCode.INVALID_CONFIRM_PROBLEM.getMessage() +
                         String.join("번 ", invalidProblemIds) + "번";
-                throw new InvalidValueException(message, ErrorCode.INVALID_CONFIRM_PROBLEM);
+                throw new ProblemSetToggleException(message);
             }
         }
         this.confirmStatus = this.confirmStatus.toggle();

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetRepository.java
@@ -3,6 +3,7 @@ package com.moplus.moplus_server.domain.problemset.repository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSetConfirmStatus;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import com.moplus.moplus_server.global.error.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,11 +13,15 @@ public interface ProblemSetRepository extends JpaRepository<ProblemSet, Long> {
         return findById(problemSetId).orElseThrow(() -> new NotFoundException(ErrorCode.PROBLEM_SET_NOT_FOUND));
     }
 
-    default void existsConfirmedActiveByIdElseThrow(Long problemSetId) {
-        if (!existsByIdAndIsDeletedFalseAndConfirmStatus(problemSetId, ProblemSetConfirmStatus.CONFIRMED)) {
-            throw new NotFoundException(ErrorCode.PROBLEM_SET_NOT_FOUND);
+    default void validatePublishableProblemSet(Long problemSetId) {
+        ProblemSet problemSet = findByIdElseThrow(problemSetId);
+
+        if (problemSet.isDeleted()) {
+            throw new InvalidValueException(ErrorCode.PROBLEM_SET_DELETED);
+        }
+
+        if (!ProblemSetConfirmStatus.CONFIRMED.equals(problemSet.getConfirmStatus())) {
+            throw new NotFoundException(ErrorCode.PROBLEM_SET_NOT_CONFIRMED);
         }
     }
-
-    boolean existsByIdAndIsDeletedFalseAndConfirmStatus(Long problemSetId, ProblemSetConfirmStatus confirmStatus);
 }

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetSearchRepositoryCustom.java
@@ -25,6 +25,7 @@ public class ProblemSetSearchRepositoryCustom {
                 .from(problemSet)
                 .leftJoin(problem).on(problem.id.in(problemSet.problemIds)) // 문제 세트 내 포함된 문항과 조인
                 .where(
+                        problemSet.isDeleted.isFalse(),
                         containsProblemSetTitle(problemSetTitle),
                         containsProblemTitle(problemTitle)
                 )
@@ -50,6 +51,7 @@ public class ProblemSetSearchRepositoryCustom {
                 .from(problemSet)
                 .leftJoin(problem).on(problem.id.in(problemSet.problemIds)) // 문제 세트 내 포함된 문항과 조인
                 .where(
+                        problemSet.isDeleted.isFalse(),
                         problemSet.confirmStatus.eq(CONFIRMED),
                         containsProblemSetTitle(problemSetTitle),
                         containsProblemTitle(problemTitle)

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
@@ -11,6 +11,8 @@ import com.moplus.moplus_server.domain.problemset.dto.response.ProblemSummaryRes
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import com.moplus.moplus_server.domain.publish.domain.Publish;
 import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.BusinessException;
+import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +31,10 @@ public class ProblemSetGetService {
 
     @Transactional(readOnly = true)
     public ProblemSetGetResponse getProblemSet(Long problemSetId) {
-
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+        if (problemSet.isDeleted()) {
+            throw new BusinessException(ErrorCode.DELETE_PROBLEM_SET_GET_ERROR);
+        }
         List<LocalDate> publishedDates = publishRepository.findByProblemSetId(problemSetId).stream()
                 .map(Publish::getPublishedDate)
                 .toList();

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetUpdateService.java
@@ -9,6 +9,7 @@ import com.moplus.moplus_server.domain.problemset.dto.request.ProblemSetUpdateRe
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
 import com.moplus.moplus_server.domain.publish.domain.Publish;
 import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
+import com.moplus.moplus_server.global.error.exception.BusinessException;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import java.util.ArrayList;
@@ -35,7 +36,9 @@ public class ProblemSetUpdateService {
     @Transactional
     public void updateProblemSet(Long problemSetId, ProblemSetUpdateRequest request) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
-
+        if (problemSet.isDeleted()) {
+            throw new BusinessException(ErrorCode.DELETE_PROBLEM_SET_UPDATE_ERROR);
+        }
         // 빈 문항 유효성 검증
         if (request.problemIds().isEmpty()) {
             throw new InvalidValueException(ErrorCode.EMPTY_PROBLEMS_ERROR);
@@ -49,6 +52,9 @@ public class ProblemSetUpdateService {
     @Transactional
     public ProblemSetConfirmStatus toggleConfirmProblemSet(Long problemSetId) {
         ProblemSet problemSet = problemSetRepository.findByIdElseThrow(problemSetId);
+        if (problemSet.isDeleted()) {
+            throw new BusinessException(ErrorCode.DELETE_PROBLEM_SET_TOGGLE_ERROR);
+        }
         List<Publish> publishes = publishRepository.findByProblemSetId(problemSetId);
         if (!publishes.isEmpty()) {
             throw new InvalidValueException(ErrorCode.ALREADY_PUBLISHED_ERROR);

--- a/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/domain/Publish.java
@@ -38,7 +38,7 @@ public class Publish extends BaseEntity {
 
     public void validatePublishedDate() {
         // 발행 시점 다음날부터 발행 가능
-        if (this.publishedDate.isBefore(LocalDate.now().plusDays(1))) {
+        if (this.publishedDate.isBefore(LocalDate.now())) {
             throw new InvalidValueException(ErrorCode.INVALID_DATE_ERROR);
         }
     }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishMonthGetResponse.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/dto/response/PublishMonthGetResponse.java
@@ -1,18 +1,19 @@
 package com.moplus.moplus_server.domain.publish.dto.response;
 
 import com.moplus.moplus_server.domain.publish.domain.Publish;
+import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record PublishMonthGetResponse(
         Long publishId,
-        int day,
+        LocalDate date,
         PublishProblemSetResponse problemSetInfo
 ) {
     public static PublishMonthGetResponse of(Publish publish, PublishProblemSetResponse problemSetInfos) {
         return PublishMonthGetResponse.builder()
                 .publishId(publish.getId())
-                .day(publish.getPublishedDate().getDayOfMonth())
+                .date(publish.getPublishedDate())
                 .problemSetInfo(problemSetInfos)
                 .build();
     }

--- a/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/publish/service/PublishSaveService.java
@@ -17,7 +17,7 @@ public class PublishSaveService {
 
     @Transactional
     public Long createPublish(PublishPostRequest request) {
-        problemSetRepository.existsConfirmedActiveByIdElseThrow(request.problemSetId());
+        problemSetRepository.validatePublishableProblemSet(request.problemSetId());
         Publish publish = request.toEntity();
         // 발행날짜 유효성 검사
         publish.validatePublishedDate();

--- a/src/main/java/com/moplus/moplus_server/global/error/ErrorResponse.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/ErrorResponse.java
@@ -20,8 +20,16 @@ public class ErrorResponse {
         this.status = code.getStatus();
     }
 
+    private ErrorResponse(final String message, final HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
     public static ErrorResponse from(final ErrorCode code) {
         return new ErrorResponse(code);
     }
 
+    public static ErrorResponse from(final String message, final HttpStatus status) {
+        return new ErrorResponse(message, status);
+    }
 }

--- a/src/main/java/com/moplus/moplus_server/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package com.moplus.moplus_server.global.error;
 
 import com.moplus.moplus_server.global.error.exception.BusinessException;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
+import com.moplus.moplus_server.global.error.exception.InvalidValueException;
 import com.moplus.moplus_server.global.error.exception.NotFoundException;
+import com.moplus.moplus_server.global.error.exception.ProblemSetToggleException;
 import com.moplus.moplus_server.global.security.exception.JwtInvalidException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -77,5 +79,14 @@ public class GlobalExceptionHandler {
         final ErrorResponse response = ErrorResponse.from(ErrorCode.BAD_CREDENTIALS);
 
         return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(ProblemSetToggleException.class)
+    protected ResponseEntity<ErrorResponse> handleProblemSetToggleException(final ProblemSetToggleException exception) {
+        log.error("handleProblemSetToggleException", exception);
+
+        final ErrorResponse response = ErrorResponse.from(exception.getMessage(), HttpStatus.BAD_REQUEST);
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -62,6 +62,9 @@ public enum ErrorCode {
     //문항세트
     PROBLEM_SET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 문항세트를 찾을 수 없습니다"),
     EMPTY_PROBLEMS_ERROR(HttpStatus.BAD_REQUEST, "적어도 1개의 문항을 등록해주세요"),
+    DELETE_PROBLEM_SET_GET_ERROR(HttpStatus.BAD_REQUEST, "삭제된 세트 문항은 조회할 수 없습니다."),
+    DELETE_PROBLEM_SET_UPDATE_ERROR(HttpStatus.BAD_REQUEST, "삭제된 세트 문항은 수정할 수 없습니다."),
+    DELETE_PROBLEM_SET_TOGGLE_ERROR(HttpStatus.BAD_REQUEST, "삭제된 세트 문항은 컨펌을 토글할 수 없습니다."),
 
     // 발행
     INVALID_MONTH_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 월입니다."),

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ErrorCode.java
@@ -72,6 +72,8 @@ public enum ErrorCode {
     PUBLISH_NOT_FOUND(HttpStatus.NOT_FOUND, "발행 정보를 찾을 수 없습니다"),
     CANNOT_DELETE_PAST_PUBLISH(HttpStatus.BAD_REQUEST, "이미 지난 발행건은 삭제할 수 없습니다."),
     ALREADY_PUBLISHED_ERROR(HttpStatus.BAD_REQUEST, "이미 발행된 문항세트는 컨펌해제할 수 없습니다."),
+    PROBLEM_SET_DELETED(HttpStatus.BAD_REQUEST, "삭제된 문항세트는 발행할 수 없습니다"),
+    PROBLEM_SET_NOT_CONFIRMED(HttpStatus.BAD_REQUEST, "컨펌되지 않은 문항세트는 발행할 수 없습니다"),
     ;
 
 

--- a/src/main/java/com/moplus/moplus_server/global/error/exception/ProblemSetToggleException.java
+++ b/src/main/java/com/moplus/moplus_server/global/error/exception/ProblemSetToggleException.java
@@ -1,0 +1,7 @@
+package com.moplus.moplus_server.global.error.exception;
+
+public class ProblemSetToggleException extends RuntimeException {
+    public ProblemSetToggleException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/problemset/ProblemSetServiceTest.java
@@ -12,6 +12,7 @@ import com.moplus.moplus_server.domain.problemset.service.ProblemSetSaveService;
 import com.moplus.moplus_server.domain.problemset.service.ProblemSetUpdateService;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
 import com.moplus.moplus_server.global.error.exception.InvalidValueException;
+import com.moplus.moplus_server.global.error.exception.ProblemSetToggleException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,7 +125,7 @@ public class ProblemSetServiceTest {
 
         // when & then
         assertThatThrownBy(() -> problemSetUpdateService.toggleConfirmProblemSet(problemSetId))
-                .isInstanceOf(InvalidValueException.class)
+                .isInstanceOf(ProblemSetToggleException.class)
                 .hasMessageContaining("24052001004번") // 메시지에 포함된 ID 확인
                 .hasMessageContaining(ErrorCode.INVALID_CONFIRM_PROBLEM.getMessage());
     }

--- a/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
@@ -80,16 +80,16 @@ public class PublishServiceTest {
     void 월별_발행_조회_테스트() {
         // given
         publishSaveService.createPublish(new PublishPostRequest(
-                LocalDate.now().plusDays(3),
+                LocalDate.now(),
                 1L
         ));
 
         // when
-        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(LocalDate.now().plusDays(3).getYear(), LocalDate.now().plusDays(3).getMonthValue());
+        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(LocalDate.now().getYear(), LocalDate.now().getMonthValue());
 
         // then
         assertThat(publishList).hasSize(1);
-        assertThat(publishList.get(0).date()).isEqualTo(LocalDate.now().plusDays(3));
+        assertThat(publishList.get(0).date()).isEqualTo(LocalDate.now());
         assertThat(publishList.get(0).problemSetInfo().title()).isEqualTo("2025년 5월 고2 모의고사 문제 세트");
     }
 
@@ -106,15 +106,12 @@ public class PublishServiceTest {
     }
 
     @Test
-    void 오늘날짜_또는_과거날짜로_발행_시_예외_테스트() {
+    void 과거날짜로_발행_시_예외_테스트() {
         // given
         LocalDate today = LocalDate.now();
         LocalDate pastDate = today.minusDays(1);
 
         // when & then (createPublish에서 예외 발생하도록)
-        assertThatThrownBy(() -> publishSaveService.createPublish(new PublishPostRequest(today, 1L)))
-                .isInstanceOf(InvalidValueException.class)
-                .hasMessageContaining(ErrorCode.INVALID_DATE_ERROR.getMessage());
 
         assertThatThrownBy(() -> publishSaveService.createPublish(new PublishPostRequest(pastDate, 1L)))
                 .isInstanceOf(InvalidValueException.class)

--- a/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
+++ b/src/test/java/com/moplus/moplus_server/domain/publish/service/PublishServiceTest.java
@@ -80,23 +80,17 @@ public class PublishServiceTest {
     void 월별_발행_조회_테스트() {
         // given
         publishSaveService.createPublish(new PublishPostRequest(
-                LocalDate.of(2025, 3, 10),
-                1L
-        ));
-
-        publishSaveService.createPublish(new PublishPostRequest(
-                LocalDate.of(2025, 3, 15),
+                LocalDate.now().plusDays(3),
                 1L
         ));
 
         // when
-        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(2025, 3);
+        List<PublishMonthGetResponse> publishList = publishGetService.getPublishMonth(LocalDate.now().plusDays(3).getYear(), LocalDate.now().plusDays(3).getMonthValue());
 
         // then
-        assertThat(publishList).hasSize(2);
-        assertThat(publishList.get(0).day()).isEqualTo(10);
+        assertThat(publishList).hasSize(1);
+        assertThat(publishList.get(0).date()).isEqualTo(LocalDate.now().plusDays(3));
         assertThat(publishList.get(0).problemSetInfo().title()).isEqualTo("2025년 5월 고2 모의고사 문제 세트");
-        assertThat(publishList.get(1).day()).isEqualTo(15);
     }
 
     @Test


### PR DESCRIPTION
# 💡 Issue
- resolved: #77 

# 📄 Description
* 발행 조회 시 연월일을 전부 내려주도록 변경했습니다.
* 당일에 발행이 가능하도록 변경했습니다.
* 삭제된 문항세트 체크가 이루어지지 않고 있었어서, 삭제된 문항세트는 조회, 검색, 수정이 불가능하게 변경했습니다.
* 빈 문항세트에 대해서 컨펌이 안되도록 변경했습니다.
* 문항세트 컨펌 실패 시, 유효성 검사에 통과하지 못한 문항들의 커스텀ID를 응답 body에 추가했습니다. 이를 위해 ProblemSetToggleException이라는 추가 에러클래스를 생성했습니다.
* 발행 실패 시 컨펌되지 않은 문항세트라 실패했는지, 삭제된 문항세트라 실패했는지에 대핸 에러 메시지를 세분화했습니다.
