### PR TITLE
[refactor/#91] 문항세트 조회 api 리팩토링

### DIFF
--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetGetRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetGetRepositoryCustom.java
@@ -1,0 +1,76 @@
+package com.moplus.moplus_server.domain.problemset.repository;
+
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
+import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
+import com.moplus.moplus_server.admin.publish.domain.QPublish;
+import com.moplus.moplus_server.domain.concept.domain.QConceptTag;
+import com.moplus.moplus_server.domain.problem.domain.problem.QProblem;
+import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemSetGetRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ProblemSetGetResponse getProblemSet(ProblemSet problemSet) {
+        // 발행 날짜 조회 쿼리
+        List<LocalDate> publishedDates = queryFactory
+                .select(QPublish.publish.publishedDate)
+                .from(QPublish.publish)
+                .where(QPublish.publish.problemSetId.eq(problemSet.getId()))
+                .fetch();
+
+        // 문제 조회 쿼리 (문제 자체 정보만 조회)
+        List<Tuple> problemData = queryFactory
+                .select(
+                        QProblem.problem.id,
+                        QProblem.problem.problemCustomId,
+                        QProblem.problem.title,
+                        QProblem.problem.memo,
+                        QProblem.problem.mainProblemImageUrl
+                )
+                .from(QProblem.problem)
+                .where(QProblem.problem.id.in(problemSet.getProblemIds()))
+                .distinct()
+                .fetch();
+
+        // 태그 조회 쿼리 (각 문제별 태그만 조회)
+        Map<Long, Set<String>> conceptTagMap = queryFactory
+                .select(QProblem.problem.id, QConceptTag.conceptTag.name)
+                .from(QProblem.problem)
+                .leftJoin(QConceptTag.conceptTag)
+                .on(QConceptTag.conceptTag.id.in(QProblem.problem.conceptTagIds))
+                .where(QProblem.problem.id.in(problemSet.getProblemIds()))
+                .fetch()
+                .stream()
+                .collect(
+                        HashMap::new,
+                        (map, tuple) -> map
+                                .computeIfAbsent(tuple.get(QProblem.problem.id), k -> new HashSet<>())
+                                .add(tuple.get(QConceptTag.conceptTag.name)),
+                        HashMap::putAll
+                );
+
+        // 문제 요약 정보 생성
+        List<ProblemSummaryResponse> problemSummaries = problemData.stream()
+                .map(tuple -> ProblemSummaryResponse.builder()
+                        .problemId(tuple.get(QProblem.problem.id))
+                        .problemCustomId(tuple.get(QProblem.problem.problemCustomId).toString())
+                        .problemTitle(tuple.get(QProblem.problem.title).toString())
+                        .memo(tuple.get(QProblem.problem.memo))
+                        .mainProblemImageUrl(tuple.get(QProblem.problem.mainProblemImageUrl))
+                        .tagNames(conceptTagMap.getOrDefault(tuple.get(QProblem.problem.id), new HashSet<>()))
+                        .build()
+                )
+                .toList();
+
+        return ProblemSetGetResponse.of(problemSet, publishedDates, problemSummaries);
+    }
+}

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetGetRepositoryCustom.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/repository/ProblemSetGetRepositoryCustom.java
@@ -31,8 +31,8 @@ public class ProblemSetGetRepositoryCustom {
         List<Tuple> problemData = queryFactory
                 .select(
                         QProblem.problem.id,
-                        QProblem.problem.problemCustomId,
-                        QProblem.problem.title,
+                        QProblem.problem.problemCustomId.id,
+                        QProblem.problem.title.title,
                         QProblem.problem.memo,
                         QProblem.problem.mainProblemImageUrl
                 )
@@ -62,8 +62,8 @@ public class ProblemSetGetRepositoryCustom {
         List<ProblemSummaryResponse> problemSummaries = problemData.stream()
                 .map(tuple -> ProblemSummaryResponse.builder()
                         .problemId(tuple.get(QProblem.problem.id))
-                        .problemCustomId(tuple.get(QProblem.problem.problemCustomId).toString())
-                        .problemTitle(tuple.get(QProblem.problem.title).toString())
+                        .problemCustomId(tuple.get(QProblem.problem.problemCustomId.id))
+                        .problemTitle(tuple.get(QProblem.problem.title.title))
                         .memo(tuple.get(QProblem.problem.memo))
                         .mainProblemImageUrl(tuple.get(QProblem.problem.mainProblemImageUrl))
                         .tagNames(conceptTagMap.getOrDefault(tuple.get(QProblem.problem.id), new HashSet<>()))

--- a/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
+++ b/src/main/java/com/moplus/moplus_server/domain/problemset/service/ProblemSetGetService.java
@@ -1,22 +1,11 @@
 package com.moplus.moplus_server.domain.problemset.service;
 
-import com.moplus.moplus_server.domain.concept.domain.ConceptTag;
-import com.moplus.moplus_server.domain.concept.repository.ConceptTagRepository;
-import com.moplus.moplus_server.domain.problem.domain.problem.Problem;
-import com.moplus.moplus_server.domain.problem.repository.ProblemRepository;
 import com.moplus.moplus_server.domain.problemset.domain.ProblemSet;
 import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSetGetResponse;
-import com.moplus.moplus_server.admin.problemset.dto.response.ProblemSummaryResponse;
+import com.moplus.moplus_server.domain.problemset.repository.ProblemSetGetRepositoryCustom;
 import com.moplus.moplus_server.domain.problemset.repository.ProblemSetRepository;
-import com.moplus.moplus_server.admin.publish.domain.Publish;
-import com.moplus.moplus_server.domain.publish.repository.PublishRepository;
 import com.moplus.moplus_server.global.error.exception.BusinessException;
 import com.moplus.moplus_server.global.error.exception.ErrorCode;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,9 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProblemSetGetService {
 
     private final ProblemSetRepository problemSetRepository;
-    private final ProblemRepository problemRepository;
-    private final ConceptTagRepository conceptTagRepository;
-    private final PublishRepository publishRepository;
+    private final ProblemSetGetRepositoryCustom problemSetGetRepositoryCustom;
 
     @Transactional(readOnly = true)
     public ProblemSetGetResponse getProblemSet(Long problemSetId) {
@@ -36,23 +23,6 @@ public class ProblemSetGetService {
         if (problemSet.isDeleted()) {
             throw new BusinessException(ErrorCode.DELETE_PROBLEM_SET_GET_ERROR);
         }
-        List<LocalDate> publishedDates = publishRepository.findByProblemSetId(problemSetId).stream()
-                .map(Publish::getPublishedDate)
-                .toList();
-
-        List<ProblemSummaryResponse> problemSummaries = new ArrayList<>();
-        for (Long problemId : problemSet.getProblemIds()) {
-            Problem problem = problemRepository.findByIdElseThrow(problemId);
-            Set<String> tagNames = new HashSet<>(
-                    conceptTagRepository.findAllByIdsElseThrow(problem.getConceptTagIds())
-                            .stream()
-                            .map(ConceptTag::getName)
-                            .toList());
-            problem.getChildProblems().stream()
-                    .map(childProblem -> conceptTagRepository.findAllByIdsElseThrow(childProblem.getConceptTagIds()))
-                    .forEach(conceptTags -> tagNames.addAll(conceptTags.stream().map(ConceptTag::getName).toList()));
-            problemSummaries.add(ProblemSummaryResponse.of(problem, tagNames));
-        }
-        return ProblemSetGetResponse.of(problemSet, publishedDates, problemSummaries);
+        return problemSetGetRepositoryCustom.getProblemSet(problemSet);
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #91 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 기존 무식하게 구현되어있던 문항세트 조회 api를 개선했습니다.
- QueryDsl을 활용하여 복잡한 쿼리를 가독성있는 코드로 작성했습니다.
- 최초 존재하는 문항세트인지 체크하는 조회쿼리와, 발해날짜들을 조회하는 쿼리는 제외한 쿼리들을 중점적으로 설명드리겠습니다.

### 기존 쿼리

- 문항세트에 속한 문항들을 개별 조회
- 문항에 속한 개념태그들을 개별 조회
- SELECT절에 엔티티가 포함되어, 불필요한 필드들도 조회

- 위와 같은 문제점들 때문에, 문항세트에 속한 문항의 개수와 문항에 속한 개념태그들의 수가 늘어남에 따라 쿼리의 개수도 배로 증가하는 구조였습니다.

### 개선된 쿼리

- 문항세트에 속한 문항ID들을 조회합니다.
- 조회한 문항ID들을 IN절로 문항 필드들을 조회합니다.
- 조회한 문항에 속한 개념태그ID들을 IN절로 조회합니다.
- SELECT절에 필요한 필드만 명시적으로 남겼습니다.

- 최종적으로 총 3번의 쿼리로 개선했습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 추후, 개념태그가 많은 문항 더미 데이터들을 추가하여 부하테스트를 통해 비교해보면 좋을 것 같습니다.

